### PR TITLE
fix: 메일 에디터 툴바 reactive 동기화 + 텍스트 정렬 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@tiptap/extension-table-header": "^3.15.3",
     "@tiptap/extension-table-row": "^3.15.3",
     "@tiptap/extension-text": "^3.15.3",
+    "@tiptap/extension-text-align": "3.15.3",
     "@tiptap/extension-text-style": "^3.15.3",
     "@tiptap/extension-underline": "^3.15.3",
     "@tiptap/pm": "3.15.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ dependencies:
   '@tiptap/extension-text':
     specifier: ^3.15.3
     version: 3.15.3(@tiptap/core@3.15.3)
+  '@tiptap/extension-text-align':
+    specifier: 3.15.3
+    version: 3.15.3(@tiptap/core@3.15.3)
   '@tiptap/extension-text-style':
     specifier: ^3.15.3
     version: 3.15.3(@tiptap/core@3.15.3)
@@ -5893,6 +5896,14 @@ packages:
     dependencies:
       '@tiptap/core': 3.15.3(@tiptap/pm@3.15.3)
       '@tiptap/pm': 3.15.3
+    dev: false
+
+  /@tiptap/extension-text-align@3.15.3(@tiptap/core@3.15.3):
+    resolution: {integrity: sha512-hkLeEKm44aqimyjv+D8JUxzDG/iNjDrSCGvGrMOPcpaKn4f8C5z1EKnEufT61RitNPBAxQMXUhmGQUNrmlICmQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.15.3
+    dependencies:
+      '@tiptap/core': 3.15.3(@tiptap/pm@3.15.3)
     dev: false
 
   /@tiptap/extension-text-style@3.15.3(@tiptap/core@3.15.3):

--- a/src/components/operations/mail-template/editor-extensions.ts
+++ b/src/components/operations/mail-template/editor-extensions.ts
@@ -17,6 +17,7 @@ import { Table } from '@tiptap/extension-table';
 import { TableCell } from '@tiptap/extension-table-cell';
 import { TableRow } from '@tiptap/extension-table-row';
 import Text from '@tiptap/extension-text';
+import { TextAlign } from '@tiptap/extension-text-align';
 import { TextStyle } from '@tiptap/extension-text-style';
 import Underline from '@tiptap/extension-underline';
 
@@ -106,6 +107,11 @@ export function createMailEditorExtensions(): AnyExtension[] {
     TextStyle,
     FontSize,
     Heading.configure({ levels: [1, 2, 3] }),
+    TextAlign.configure({
+      types: ['paragraph', 'heading'],
+      alignments: ['left', 'center', 'right', 'justify'],
+      defaultAlignment: 'left',
+    }),
     BulletList,
     OrderedList,
     ListItem,

--- a/src/components/operations/mail-template/editor-toolbar.tsx
+++ b/src/components/operations/mail-template/editor-toolbar.tsx
@@ -1,7 +1,11 @@
 'use client';
 
-import type { Editor } from '@tiptap/react';
+import { useEditorState, type Editor } from '@tiptap/react';
 import {
+  AlignCenter,
+  AlignJustify,
+  AlignLeft,
+  AlignRight,
   Bold,
   Image as ImageIcon,
   Italic,
@@ -12,6 +16,8 @@ import {
   Underline,
   Undo,
 } from 'lucide-react';
+
+import { findTableAtSelection } from '@/lib/tiptap/find-table';
 
 import { PopoverVariableMenu } from './popover-variable-menu';
 import { TableContextToolbar } from './table-context-toolbar';
@@ -29,6 +35,42 @@ interface Props {
 const FONT_SIZES = [12, 14, 16, 18, 20, 24, 28, 32] as const;
 
 export function EditorToolbar({ editor, catalog, onPickImage, onPickLink }: Props) {
+  const s = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      if (!editor) {
+        return {
+          bold: false,
+          italic: false,
+          underline: false,
+          bulletList: false,
+          orderedList: false,
+          alignLeft: true,
+          alignCenter: false,
+          alignRight: false,
+          alignJustify: false,
+          canUndo: false,
+          canRedo: false,
+          tableActive: false,
+        };
+      }
+      return {
+        bold: editor.isActive('bold'),
+        italic: editor.isActive('italic'),
+        underline: editor.isActive('underline'),
+        bulletList: editor.isActive('bulletList'),
+        orderedList: editor.isActive('orderedList'),
+        alignLeft: editor.isActive({ textAlign: 'left' }),
+        alignCenter: editor.isActive({ textAlign: 'center' }),
+        alignRight: editor.isActive({ textAlign: 'right' }),
+        alignJustify: editor.isActive({ textAlign: 'justify' }),
+        canUndo: editor.can().undo(),
+        canRedo: editor.can().redo(),
+        tableActive: findTableAtSelection(editor.state) !== null,
+      };
+    },
+  });
+
   const insertVar = (key: string) => {
     editor.chain().focus().insertContent(`{{${key}}}`).run();
   };
@@ -37,27 +79,24 @@ export function EditorToolbar({ editor, catalog, onPickImage, onPickLink }: Prop
     editor.chain().focus().setFontSize(`${px}px`).run();
   };
 
-  // 표 안에 셀렉션이 있을 때만 표 컨텍스트 툴바 노출
-  const tableActive = editor.can().deleteTable();
-
   return (
     <div className="flex flex-wrap items-center gap-1 border-b border-gray-200 bg-gray-50/50 p-2">
       <ToolBtn
-        active={editor.isActive('bold')}
+        active={s.bold}
         onClick={() => editor.chain().focus().toggleBold().run()}
         title="굵게"
       >
         <Bold className="h-4 w-4" />
       </ToolBtn>
       <ToolBtn
-        active={editor.isActive('italic')}
+        active={s.italic}
         onClick={() => editor.chain().focus().toggleItalic().run()}
         title="기울임"
       >
         <Italic className="h-4 w-4" />
       </ToolBtn>
       <ToolBtn
-        active={editor.isActive('underline')}
+        active={s.underline}
         onClick={() => editor.chain().focus().toggleUnderline().run()}
         title="밑줄"
       >
@@ -70,9 +109,9 @@ export function EditorToolbar({ editor, catalog, onPickImage, onPickLink }: Prop
         defaultValue="14"
         aria-label="폰트 크기"
       >
-        {FONT_SIZES.map((s) => (
-          <option key={s} value={s}>
-            {s}px
+        {FONT_SIZES.map((sz) => (
+          <option key={sz} value={sz}>
+            {sz}px
           </option>
         ))}
       </select>
@@ -80,18 +119,49 @@ export function EditorToolbar({ editor, catalog, onPickImage, onPickLink }: Prop
       <Sep />
 
       <ToolBtn
-        active={editor.isActive('bulletList')}
+        active={s.bulletList}
         onClick={() => editor.chain().focus().toggleBulletList().run()}
         title="글머리 기호"
       >
         <List className="h-4 w-4" />
       </ToolBtn>
       <ToolBtn
-        active={editor.isActive('orderedList')}
+        active={s.orderedList}
         onClick={() => editor.chain().focus().toggleOrderedList().run()}
         title="번호 매기기"
       >
         <ListOrdered className="h-4 w-4" />
+      </ToolBtn>
+
+      <Sep />
+
+      <ToolBtn
+        active={s.alignLeft}
+        onClick={() => editor.chain().focus().setTextAlign('left').run()}
+        title="왼쪽 정렬"
+      >
+        <AlignLeft className="h-4 w-4" />
+      </ToolBtn>
+      <ToolBtn
+        active={s.alignCenter}
+        onClick={() => editor.chain().focus().setTextAlign('center').run()}
+        title="가운데 정렬"
+      >
+        <AlignCenter className="h-4 w-4" />
+      </ToolBtn>
+      <ToolBtn
+        active={s.alignRight}
+        onClick={() => editor.chain().focus().setTextAlign('right').run()}
+        title="오른쪽 정렬"
+      >
+        <AlignRight className="h-4 w-4" />
+      </ToolBtn>
+      <ToolBtn
+        active={s.alignJustify}
+        onClick={() => editor.chain().focus().setTextAlign('justify').run()}
+        title="양쪽 정렬"
+      >
+        <AlignJustify className="h-4 w-4" />
       </ToolBtn>
 
       <Sep />
@@ -112,21 +182,21 @@ export function EditorToolbar({ editor, catalog, onPickImage, onPickLink }: Prop
       <div className="ml-auto flex gap-1">
         <ToolBtn
           onClick={() => editor.chain().focus().undo().run()}
-          disabled={!editor.can().undo()}
+          disabled={!s.canUndo}
           title="실행 취소"
         >
           <Undo className="h-4 w-4" />
         </ToolBtn>
         <ToolBtn
           onClick={() => editor.chain().focus().redo().run()}
-          disabled={!editor.can().redo()}
+          disabled={!s.canRedo}
           title="다시 실행"
         >
           <Redo className="h-4 w-4" />
         </ToolBtn>
       </div>
 
-      {tableActive && <TableContextToolbar editor={editor} />}
+      {s.tableActive && <TableContextToolbar editor={editor} />}
     </div>
   );
 }

--- a/src/components/operations/mail-template/mail-template-editor.tsx
+++ b/src/components/operations/mail-template/mail-template-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from 'react';
+import { forwardRef, useEffect, useImperativeHandle, useMemo } from 'react';
 
 import { EditorContent, useEditor } from '@tiptap/react';
 
@@ -26,7 +26,6 @@ export interface MailTemplateEditorHandle {
 export const MailTemplateEditor = forwardRef<MailTemplateEditorHandle, Props>(
   function MailTemplateEditor({ initialHtml, catalog, onChange }, ref) {
     const extensions = useMemo(() => createMailEditorExtensions(), []);
-    const [, force] = useState({});
     const imageTracker = useEditorImageTracker(initialHtml);
 
     const editor = useEditor({
@@ -37,23 +36,24 @@ export const MailTemplateEditor = forwardRef<MailTemplateEditorHandle, Props>(
         attributes: {
           class:
             'prose prose-sm max-w-none focus:outline-none min-h-[320px] p-6 ' +
+            // typography 플러그인 미사용 환경에서 ul/ol 마커가 사라지므로 인라인으로 복원
+            '[&_ul]:list-disc [&_ul]:pl-6 [&_ul]:my-2 ' +
+            '[&_ol]:list-decimal [&_ol]:pl-6 [&_ol]:my-2 ' +
+            '[&_li]:my-0.5 [&_li>p]:my-0 ' +
             '[&_table]:my-2 [&_table]:border [&_table]:border-gray-300 ' +
-            '[&_table_td]:border [&_table_td]:border-gray-300 [&_table_td]:px-2 [&_table_td]:py-1 ' +
-            '[&_table_caption]:py-2 [&_table_caption]:text-sm [&_table_caption]:text-gray-700',
+            '[&_table_td]:border [&_table_td]:border-gray-300 [&_table_td]:px-2 [&_table_td]:py-1 [&_table_td]:h-12 ' +
+            // td 세로 정렬이 시각적으로 보이려면 안쪽 paragraph가 셀 전체 높이를 차지하지 않아야 한다.
+            '[&_table_td_p]:m-0 ' +
+            '[&_table_caption]:py-2 [&_table_caption]:text-sm [&_table_caption]:text-gray-700 ' +
+            // prosemirror-tables 셀 드래그 selection 시각 피드백
+            '[&_td.selectedCell]:relative [&_td.selectedCell]:bg-blue-100/60 ' +
+            '[&_th.selectedCell]:relative [&_th.selectedCell]:bg-blue-100/60',
         },
       },
       onUpdate: ({ editor }) => {
-        force({});
         const currentHtml = stripTrailingEmptyParagraph(editor.getHTML());
         imageTracker.reconcileAfterUpdate(currentHtml);
         onChange(editor.isEmpty ? '' : currentHtml);
-      },
-      onSelectionUpdate: () => {
-        force({});
-      },
-      onTransaction: () => {
-        // mark 토글 등 셀렉션이 안 바뀌는 변경도 툴바 active 동기화
-        force({});
       },
     });
 

--- a/src/components/operations/mail-template/table-caption.ts
+++ b/src/components/operations/mail-template/table-caption.ts
@@ -1,6 +1,8 @@
 import { Node } from '@tiptap/core';
 import type { Editor } from '@tiptap/core';
-import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { TextSelection } from '@tiptap/pm/state';
+
+import { findTableAtSelection } from '@/lib/tiptap/find-table';
 
 import { parseCaptionAlign, captionAlignStyle, type HAlign } from './table-attrs-helpers';
 
@@ -39,47 +41,28 @@ export const TableCaption = Node.create({
  * - 셀렉션이 표 밖이면 no-op
  */
 export function toggleTableCaption(editor: Editor): boolean {
-  if (!editor.isActive('table')) return false;
+  const { state, view } = editor;
+  const found = findTableAtSelection(state);
+  if (!found) return false;
 
-  const { state } = editor;
-  const { selection, schema } = state;
-  const $pos = selection.$from;
-
-  // 커서 위치에서 부모 체인을 거슬러 올라가며 table 노드 찾기
-  let tablePos: number | null = null;
-  let tableNode: ProseMirrorNode | null = null;
-  for (let d = $pos.depth; d > 0; d--) {
-    const node = $pos.node(d);
-    if (node.type.name === 'table') {
-      tablePos = $pos.before(d);
-      tableNode = node;
-      break;
-    }
-  }
-
-  if (tablePos === null || !tableNode) return false;
-
+  const { node: tableNode, pos: tablePos } = found;
   const firstChild = tableNode.firstChild;
-  const insertPos = tablePos + 1; // 표 노드 안의 첫 위치
+  const insertPos = tablePos + 1;
 
   if (firstChild?.type.name === 'tableCaption') {
-    // 캡션 제거
-    return editor
-      .chain()
-      .focus()
-      .deleteRange({ from: insertPos, to: insertPos + firstChild.nodeSize })
-      .run();
+    view.dispatch(state.tr.delete(insertPos, insertPos + firstChild.nodeSize));
+    editor.commands.focus();
+    return true;
   }
 
-  // 캡션 신규 삽입 — 빈 inline content
-  const captionType = schema.nodes.tableCaption;
+  // TipTap의 insertContentAt은 schema 매칭 실패 시 inline으로 fallback돼
+  // 캡션 노드가 셀 안으로 빨려들어가는 문제가 있다. transaction으로 직접 삽입.
+  const captionType = state.schema.nodes.tableCaption;
   if (!captionType) return false;
-  const captionNode = captionType.create({ align: 'center' });
 
-  return editor
-    .chain()
-    .focus()
-    .insertContentAt(insertPos, captionNode, { updateSelection: false })
-    .setTextSelection(insertPos + 1) // 캡션 안으로 커서
-    .run();
+  const tr = state.tr.insert(insertPos, captionType.create({ align: 'center' }));
+  tr.setSelection(TextSelection.create(tr.doc, insertPos + 1));
+  view.dispatch(tr.scrollIntoView());
+  editor.commands.focus();
+  return true;
 }

--- a/src/components/operations/mail-template/table-context-toolbar.tsx
+++ b/src/components/operations/mail-template/table-context-toolbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { Editor } from '@tiptap/react';
+import { useEditorState, type Editor } from '@tiptap/react';
 import {
   AlignCenter,
   AlignLeft,
@@ -25,15 +25,35 @@ interface Props {
   editor: Editor;
 }
 
-export function TableContextToolbar({ editor }: Props) {
-  const captionActive = editor.isActive('tableCaption');
+type HAlign = 'left' | 'center' | 'right';
+type VAlign = 'top' | 'middle' | 'bottom';
 
-  const currentTableAlign = (editor.getAttributes('table').align ?? 'left') as
-    | 'left' | 'center' | 'right';
-  const currentCellVAlign = (editor.getAttributes('tableCell').verticalAlign ?? 'top') as
-    | 'top' | 'middle' | 'bottom';
-  const currentCaptionAlign = (editor.getAttributes('tableCaption').align ?? 'center') as
-    | 'left' | 'center' | 'right';
+export function TableContextToolbar({ editor }: Props) {
+  const s = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      if (!editor) {
+        return {
+          captionActive: false,
+          cellVAlign: 'top' as VAlign,
+          captionAlign: 'center' as HAlign,
+          canMergeCells: false,
+          canSplitCell: false,
+          canDeleteColumn: false,
+          canDeleteRow: false,
+        };
+      }
+      return {
+        captionActive: editor.isActive('tableCaption'),
+        cellVAlign: (editor.getAttributes('tableCell').verticalAlign ?? 'top') as VAlign,
+        captionAlign: (editor.getAttributes('tableCaption').align ?? 'center') as HAlign,
+        canMergeCells: editor.can().mergeCells(),
+        canSplitCell: editor.can().splitCell(),
+        canDeleteColumn: editor.can().deleteColumn(),
+        canDeleteRow: editor.can().deleteRow(),
+      };
+    },
+  });
 
   return (
     <div className="flex w-full flex-wrap items-center gap-1 border-t border-gray-200 pt-2">
@@ -46,7 +66,7 @@ export function TableContextToolbar({ editor }: Props) {
       </ToolBtn>
       <ToolBtn
         title="열 삭제"
-        disabled={!editor.can().deleteColumn()}
+        disabled={!s.canDeleteColumn}
         onClick={() => editor.chain().focus().deleteColumn().run()}
         className="text-red-600 hover:bg-red-50"
       >
@@ -55,7 +75,7 @@ export function TableContextToolbar({ editor }: Props) {
       </ToolBtn>
       <ToolBtn
         title="행 삭제"
-        disabled={!editor.can().deleteRow()}
+        disabled={!s.canDeleteRow}
         onClick={() => editor.chain().focus().deleteRow().run()}
         className="text-red-600 hover:bg-red-50"
       >
@@ -68,14 +88,14 @@ export function TableContextToolbar({ editor }: Props) {
       {/* 병합 그룹 */}
       <ToolBtn
         title="셀 병합"
-        disabled={!editor.can().mergeCells()}
+        disabled={!s.canMergeCells}
         onClick={() => editor.chain().focus().mergeCells().run()}
       >
         <Merge className="h-4 w-4" />
       </ToolBtn>
       <ToolBtn
         title="셀 분할"
-        disabled={!editor.can().splitCell()}
+        disabled={!s.canSplitCell}
         onClick={() => editor.chain().focus().splitCell().run()}
       >
         <Split className="h-4 w-4" />
@@ -86,7 +106,7 @@ export function TableContextToolbar({ editor }: Props) {
       {/* 셀 vertical-align */}
       <ToolBtn
         title="셀 위쪽"
-        active={currentCellVAlign === 'top'}
+        active={s.cellVAlign === 'top'}
         onClick={() =>
           editor.chain().focus().updateAttributes('tableCell', { verticalAlign: 'top' }).run()
         }
@@ -95,7 +115,7 @@ export function TableContextToolbar({ editor }: Props) {
       </ToolBtn>
       <ToolBtn
         title="셀 가운데"
-        active={currentCellVAlign === 'middle'}
+        active={s.cellVAlign === 'middle'}
         onClick={() =>
           editor.chain().focus().updateAttributes('tableCell', { verticalAlign: 'middle' }).run()
         }
@@ -104,43 +124,12 @@ export function TableContextToolbar({ editor }: Props) {
       </ToolBtn>
       <ToolBtn
         title="셀 아래쪽"
-        active={currentCellVAlign === 'bottom'}
+        active={s.cellVAlign === 'bottom'}
         onClick={() =>
           editor.chain().focus().updateAttributes('tableCell', { verticalAlign: 'bottom' }).run()
         }
       >
         <AlignVerticalJustifyEnd className="h-4 w-4" />
-      </ToolBtn>
-
-      <Sep />
-
-      {/* 표 정렬 */}
-      <ToolBtn
-        title="표 왼쪽"
-        active={currentTableAlign === 'left'}
-        onClick={() =>
-          editor.chain().focus().updateAttributes('table', { align: 'left' }).run()
-        }
-      >
-        <AlignLeft className="h-4 w-4" />
-      </ToolBtn>
-      <ToolBtn
-        title="표 가운데"
-        active={currentTableAlign === 'center'}
-        onClick={() =>
-          editor.chain().focus().updateAttributes('table', { align: 'center' }).run()
-        }
-      >
-        <AlignCenter className="h-4 w-4" />
-      </ToolBtn>
-      <ToolBtn
-        title="표 오른쪽"
-        active={currentTableAlign === 'right'}
-        onClick={() =>
-          editor.chain().focus().updateAttributes('table', { align: 'right' }).run()
-        }
-      >
-        <AlignRight className="h-4 w-4" />
       </ToolBtn>
 
       <Sep />
@@ -177,19 +166,19 @@ export function TableContextToolbar({ editor }: Props) {
 
       {/* 캡션 토글 */}
       <ToolBtn
-        title={captionActive ? '캡션 제거' : '캡션 추가'}
-        active={captionActive}
+        title={s.captionActive ? '캡션 제거' : '캡션 추가'}
+        active={s.captionActive}
         onClick={() => toggleTableCaption(editor)}
       >
         <Captions className="h-4 w-4" />
       </ToolBtn>
 
       {/* 캡션 정렬 — 캡션 focus 시만 노출 */}
-      {captionActive && (
+      {s.captionActive && (
         <>
           <ToolBtn
             title="캡션 왼쪽"
-            active={currentCaptionAlign === 'left'}
+            active={s.captionAlign === 'left'}
             onClick={() =>
               editor.chain().focus().updateAttributes('tableCaption', { align: 'left' }).run()
             }
@@ -198,7 +187,7 @@ export function TableContextToolbar({ editor }: Props) {
           </ToolBtn>
           <ToolBtn
             title="캡션 가운데"
-            active={currentCaptionAlign === 'center'}
+            active={s.captionAlign === 'center'}
             onClick={() =>
               editor.chain().focus().updateAttributes('tableCaption', { align: 'center' }).run()
             }
@@ -207,7 +196,7 @@ export function TableContextToolbar({ editor }: Props) {
           </ToolBtn>
           <ToolBtn
             title="캡션 오른쪽"
-            active={currentCaptionAlign === 'right'}
+            active={s.captionAlign === 'right'}
             onClick={() =>
               editor.chain().focus().updateAttributes('tableCaption', { align: 'right' }).run()
             }

--- a/src/components/operations/mail-template/toolbar-primitives.tsx
+++ b/src/components/operations/mail-template/toolbar-primitives.tsx
@@ -2,8 +2,6 @@
 
 import type { ReactNode } from 'react';
 
-import { Button } from '@/components/ui/button';
-
 interface ToolBtnProps {
   children: ReactNode;
   onClick?: () => void;
@@ -12,6 +10,11 @@ interface ToolBtnProps {
   title?: string;
   className?: string;
 }
+
+const BASE =
+  'inline-flex h-9 items-center justify-center gap-1 rounded-md px-2 py-1 text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50';
+const INACTIVE = 'text-gray-700 hover:bg-gray-100';
+const ACTIVE = 'bg-gray-100 text-gray-900 ring-1 ring-inset ring-gray-300';
 
 export function ToolBtn({
   children,
@@ -22,17 +25,15 @@ export function ToolBtn({
   className,
 }: ToolBtnProps) {
   return (
-    <Button
+    <button
       type="button"
-      variant="ghost"
-      size="sm"
       onClick={onClick}
       disabled={disabled}
       title={title}
-      className={`${active ? 'bg-gray-200' : ''} ${className ?? ''}`}
+      className={`${BASE} ${active ? ACTIVE : INACTIVE} ${className ?? ''}`}
     >
       {children}
-    </Button>
+    </button>
   );
 }
 

--- a/src/lib/tiptap/find-table.ts
+++ b/src/lib/tiptap/find-table.ts
@@ -1,0 +1,22 @@
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import type { EditorState } from '@tiptap/pm/state';
+
+/**
+ * 현재 selection의 부모 체인을 거슬러 올라가 가장 가까운 table 노드를 찾는다.
+ * 셀 내부 paragraph 텍스트 커서처럼 `editor.isActive('table')`로 잡히지 않는
+ * selection 케이스까지 안전하게 커버한다.
+ *
+ * @returns 찾으면 `{ node, pos }` — `pos`는 표 노드 시작 위치. 못 찾으면 `null`.
+ */
+export function findTableAtSelection(
+  state: EditorState,
+): { node: ProseMirrorNode; pos: number } | null {
+  const { $from } = state.selection;
+  for (let d = $from.depth; d > 0; d--) {
+    const node = $from.node(d);
+    if (node.type.name === 'table') {
+      return { node, pos: $from.before(d) };
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- `useEditorState` 도입 — toolbar active/disabled 상태가 매 transaction마다 정확히 갱신
- TextAlign extension 등록, 좌/중/우/양쪽 정렬 4 버튼 추가 (셀 안 포함)
- 표 컨텍스트 툴바 노출 조건을 selection 트리 직접 탐색으로 안정화
- 캡션 토글이 셀 안으로 빨려들어가던 버그 — ProseMirror transaction 직접 발행으로 수정
- 셀 vertical-align 시각화를 위해 `td` 최소 높이 + paragraph margin 0
- 표 컨테이너 align UI 제거 (schema/시리얼라이저는 호환성 위해 보존)
- `findTableAtSelection` 헬퍼 추출 — `editor-toolbar` / `table-caption` 중복 통합

## Test plan

- [ ] B/I/U/리스트/정렬 버튼 — 토글 시 회색 active 표시 즉시 반영
- [ ] 표 셀에 커서 → 컨텍스트 툴바 노출, 표 밖 클릭 → 사라짐
- [ ] 셀 두 개 이상 드래그 → 파란 selection 표시, 병합/분할 버튼 활성
- [ ] 캡션 추가 → 표 위쪽에 캡션 영역 + 커서 캡션 안으로 이동
- [ ] 셀 위/가운데/아래 버튼 — 셀 안 텍스트가 위/중/아래로 명확히 이동
- [ ] 메일 본문에서 좌/중/우/양쪽 정렬 버튼 — 단락 정렬 적용 + active 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)