### PR TITLE
feat: 컨택 PII 사이드 테이블 + 암호화 인프라 도입

### DIFF
--- a/src/actions/contact-actions.ts
+++ b/src/actions/contact-actions.ts
@@ -15,6 +15,14 @@ import type {
 } from '@/db/schema/schema-types';
 import { requireAuth } from '@/lib/auth';
 import { parseExcelRows, previewExcel } from '@/lib/contacts/excel-parser';
+import { sanitizeAttrsAgainstPii } from '@/lib/contacts/scheme-helpers';
+import {
+  buildPiiRows,
+  insertPiiRows,
+  upsertPiiValue,
+  type PiiInput,
+} from '@/lib/crypto/contact-pii-repo';
+import type { PiiFieldType } from '@/lib/crypto/pii-fields';
 
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024; // 10MB
 const MAX_ROWS = 5000;
@@ -117,15 +125,19 @@ export async function ingestContactUpload(
   }
 
   const headerKeys = allRows.length > 0 ? Object.keys(allRows[0]) : [];
-  const groupKey = headerKeys[mapping.systemFields.group];
-  const emailKey =
-    mapping.systemFields.email != null ? headerKeys[mapping.systemFields.email] : null;
-  const bizKey =
-    mapping.systemFields.biz != null ? headerKeys[mapping.systemFields.biz] : null;
+  // 분류 기준은 선택사항 — 미지정 시 모든 행의 group_value = NULL
+  const groupKey =
+    mapping.systemFields.group != null ? (headerKeys[mapping.systemFields.group] ?? null) : null;
 
-  if (!groupKey) {
-    throw new Error('그룹 컬럼이 매핑되지 않았습니다.');
+  // 매핑된 PII 컬럼만 추출. 헤더에 없는 키는 자동 드롭.
+  const piiEntries: Array<{ columnKey: string; fieldType: PiiFieldType }> = [];
+  const piiMapping = mapping.piiMapping ?? {};
+  for (const [columnKey, fieldType] of Object.entries(piiMapping)) {
+    if (headerKeys.includes(columnKey)) {
+      piiEntries.push({ columnKey, fieldType });
+    }
   }
+  const piiKeySet = new Set(piiEntries.map((e) => e.columnKey));
 
   let uploadedRows = 0;
   let mergedRows = 0;
@@ -133,8 +145,7 @@ export async function ingestContactUpload(
 
   const result = await db.transaction(async (tx) => {
     // 시나리오 B: 기존 컨택 통째 DELETE.
-    // FK 동작: survey_responses 는 SET NULL (응답 보존), contact_attempts 는 CASCADE.
-    // 클라이언트가 경고 confirm 후 호출 — 서버는 가드 없이 실행.
+    // FK 동작: survey_responses 는 SET NULL (응답 보존), contact_attempts/contact_pii 는 CASCADE.
     await tx.delete(contactTargets).where(eq(contactTargets.surveyId, surveyId));
 
     const [upload] = await tx
@@ -154,9 +165,13 @@ export async function ingestContactUpload(
     for (const row of allRows) {
       try {
         await tx.transaction(async (sp) => {
-          const groupValue = row[groupKey] || null;
-          const email = emailKey ? row[emailKey] || null : null;
-          const biz = bizKey ? row[bizKey] || null : null;
+          const groupValue = groupKey ? (row[groupKey] || null) : null;
+
+          // attrs 에서 PII 키 제외 — PII 는 contact_pii 사이드 테이블에만 저장
+          const cleanAttrs: Record<string, string> = {};
+          for (const [k, v] of Object.entries(row)) {
+            if (!piiKeySet.has(k)) cleanAttrs[k] = v;
+          }
 
           const residRows = (await sp.execute(
             sql`SELECT next_contact_resid(${surveyId}::uuid) AS resid`,
@@ -164,15 +179,29 @@ export async function ingestContactUpload(
           const resid = residRows[0]?.resid;
           if (resid == null) throw new Error('next_contact_resid 호출 실패');
 
-          await sp.insert(contactTargets).values({
-            surveyId,
-            resid,
-            groupValue,
-            email,
-            bizNumber: biz,
-            attrs: row,
-            uploadId: upload.id,
-          });
+          const [target] = await sp
+            .insert(contactTargets)
+            .values({
+              surveyId,
+              resid,
+              groupValue,
+              attrs: cleanAttrs,
+              uploadId: upload.id,
+            })
+            .returning({ id: contactTargets.id });
+          if (!target) throw new Error('contact_targets INSERT 실패');
+
+          // PII 추출 + 암호화 저장 (buildPiiRows 가 빈 값/정규화 후 빈 값 자동 스킵)
+          if (piiEntries.length > 0) {
+            const piiInputs: PiiInput[] = piiEntries.map((e) => ({
+              columnKey: e.columnKey,
+              fieldType: e.fieldType,
+              plain: row[e.columnKey] ?? '',
+            }));
+            const piiRows = buildPiiRows(target.id, piiInputs);
+            await insertPiiRows(sp, piiRows);
+          }
+
           uploadedRows += 1;
         });
       } catch (e) {
@@ -208,17 +237,35 @@ function autoGenerateColumnScheme(
   // 시스템 컬럼 (resid 항상 1번, 표시 필수)
   columns.push({ key: 'resid', label: '#', source: 'system.resid', order: order++ });
 
-  // 모든 attrs 헤더 키를 컬럼으로 등록.
+  // 모든 헤더 키를 컬럼으로 등록.
+  // - piiMapping 에 매핑된 헤더 → source 'pii.<key>' + piiType 명시 → contact_pii 테이블 조인 후 표시
+  // - 그 외 → source 'attrs.<key>' → contact_targets.attrs JSONB 에서 표시
   // 사용자가 매핑 모달에서 토글한 키만 hidden:false, 나머지는 hidden:true.
   const selected = new Set(mapping.selectedAttrsKeys);
+  const piiMapping = mapping.piiMapping ?? {};
+  const labelOverrides = mapping.labelOverrides ?? {};
+
   for (const key of headerKeys) {
-    columns.push({
-      key,
-      label: key,
-      source: `attrs.${key}`,
-      order: order++,
-      hidden: !selected.has(key),
-    });
+    const piiType = piiMapping[key];
+    const label = labelOverrides[key] ?? key;
+    if (piiType) {
+      columns.push({
+        key,
+        label,
+        source: `pii.${key}`,
+        order: order++,
+        hidden: !selected.has(key),
+        piiType,
+      });
+    } else {
+      columns.push({
+        key,
+        label,
+        source: `attrs.${key}`,
+        order: order++,
+        hidden: !selected.has(key),
+      });
+    }
   }
 
   // 운영 컬럼 (read 만, 본 슬라이스)
@@ -263,16 +310,25 @@ export async function getExistingContactsCount(surveyId: string): Promise<number
 // 행 단위 CRUD (시나리오 B — 한 번 업로드 후 명단 갱신)
 // ─────────────────────────────────────────────────────────────────────────────
 
+export interface PiiUpdate {
+  /** ContactColumnDef.source 가 'pii.<columnKey>' 인 컬럼의 columnKey */
+  columnKey: string;
+  fieldType: PiiFieldType;
+  /** 평문값. 빈 문자열이면 기존 PII row 삭제. */
+  plain: string;
+}
+
+
 export interface AddContactTargetInput {
   surveyId: string;
   attrs: Record<string, string>;
+  /** PII 컬럼 값 (재암호화 후 contact_pii 에 저장) */
+  piiUpdates?: PiiUpdate[];
   memo?: string | null;
   contactMethod?: ContactMethod | null;
   /** 시스템 필드는 attrs 의 어느 키에 있는지 — 컬럼 스킴의 systemFields 맵 활용 */
   systemFieldKeys?: {
     group?: string;
-    email?: string;
-    biz?: string;
   };
 }
 
@@ -284,16 +340,18 @@ export interface ContactTargetRow {
 /**
  * 컨택리스트의 "+ 컨택 추가" 모달 저장 액션.
  * resid 는 next_contact_resid() 로 자동 발번.
+ * PII 컬럼은 piiUpdates 로 별도 전달 → contact_pii 에 암호화 저장.
  */
 export async function addContactTarget(
   input: AddContactTargetInput,
 ): Promise<ContactTargetRow> {
   await requireAuth();
-  const { surveyId, attrs, memo, contactMethod, systemFieldKeys } = input;
+  const { surveyId, attrs: rawAttrs, piiUpdates, memo, contactMethod, systemFieldKeys } = input;
+
+  // UI 우회로 PII 키가 attrs 에 섞여 들어오는 경우 차단 — 평문 누적 방지.
+  const attrs = await sanitizeAttrsAgainstPii(surveyId, rawAttrs);
 
   const groupValue = systemFieldKeys?.group ? (attrs[systemFieldKeys.group] || null) : null;
-  const email = systemFieldKeys?.email ? (attrs[systemFieldKeys.email] || null) : null;
-  const biz = systemFieldKeys?.biz ? (attrs[systemFieldKeys.biz] || null) : null;
 
   const result = await db.transaction(async (tx) => {
     const residRows = (await tx.execute(
@@ -308,14 +366,19 @@ export async function addContactTarget(
         surveyId,
         resid,
         groupValue,
-        email,
-        bizNumber: biz,
         attrs,
         memo: memo ?? null,
         contactMethod: contactMethod ?? null,
       })
       .returning({ id: contactTargets.id, resid: contactTargets.resid });
     if (!row) throw new Error('contact_targets INSERT 실패');
+
+    if (piiUpdates && piiUpdates.length > 0) {
+      for (const p of piiUpdates) {
+        await upsertPiiValue(tx, row.id, p.columnKey, p.fieldType, p.plain);
+      }
+    }
+
     return row;
   });
 
@@ -327,12 +390,12 @@ export interface UpdateContactTargetInput {
   id: string;
   surveyId: string;
   attrs: Record<string, string>;
+  /** PII 컬럼 값 변경분 (재암호화 후 upsert). 변경 없는 컬럼은 보내지 말 것. */
+  piiUpdates?: PiiUpdate[];
   memo?: string | null;
   contactMethod?: ContactMethod | null;
   systemFieldKeys?: {
     group?: string;
-    email?: string;
-    biz?: string;
   };
 }
 
@@ -340,24 +403,31 @@ export async function updateContactTarget(
   input: UpdateContactTargetInput,
 ): Promise<void> {
   await requireAuth();
-  const { id, surveyId, attrs, memo, contactMethod, systemFieldKeys } = input;
+  const { id, surveyId, attrs: rawAttrs, piiUpdates, memo, contactMethod, systemFieldKeys } = input;
+
+  // UI 우회로 PII 키가 attrs 에 섞여 들어오는 경우 차단 — 평문 누적 방지.
+  const attrs = await sanitizeAttrsAgainstPii(surveyId, rawAttrs);
 
   const groupValue = systemFieldKeys?.group ? (attrs[systemFieldKeys.group] || null) : null;
-  const email = systemFieldKeys?.email ? (attrs[systemFieldKeys.email] || null) : null;
-  const biz = systemFieldKeys?.biz ? (attrs[systemFieldKeys.biz] || null) : null;
 
-  await db
-    .update(contactTargets)
-    .set({
-      attrs,
-      groupValue,
-      email,
-      bizNumber: biz,
-      memo: memo ?? null,
-      contactMethod: contactMethod ?? null,
-      updatedAt: new Date(),
-    })
-    .where(eq(contactTargets.id, id));
+  await db.transaction(async (tx) => {
+    await tx
+      .update(contactTargets)
+      .set({
+        attrs,
+        groupValue,
+        memo: memo ?? null,
+        contactMethod: contactMethod ?? null,
+        updatedAt: new Date(),
+      })
+      .where(eq(contactTargets.id, id));
+
+    if (piiUpdates && piiUpdates.length > 0) {
+      for (const p of piiUpdates) {
+        await upsertPiiValue(tx, id, p.columnKey, p.fieldType, p.plain);
+      }
+    }
+  });
 
   revalidatePath(`/admin/surveys/${surveyId}/operations/contacts`);
   revalidatePath(`/admin/surveys/${surveyId}/operations/contacts/${id}`);

--- a/src/actions/response-actions.ts
+++ b/src/actions/response-actions.ts
@@ -25,19 +25,19 @@ import { normalizeToAnswers } from '@/lib/response-normalizer';
 /**
  * inviteToken 으로 컨택 lookup. 무효 토큰이면 null 반환 (silent fallback).
  * 액션은 mutation 흐름이라 dedupe 가 의미 없어 cache 적용 안 함.
+ *
+ * SECURITY DEFINER PG 함수 사용 — connection role 이 anon/authenticated 라도
+ * RLS 우회해서 contact_target_id 만 안전하게 조회 가능. 다른 attrs/PII 는 노출 안 됨.
  */
 async function findContactByInviteToken(
   surveyId: string,
   inviteToken: string,
 ): Promise<{ id: string } | null> {
-  const rows = await db
-    .select({ id: contactTargets.id })
-    .from(contactTargets)
-    .where(
-      and(eq(contactTargets.surveyId, surveyId), eq(contactTargets.inviteToken, inviteToken)),
-    )
-    .limit(1);
-  return rows[0] ?? null;
+  const result = (await db.execute(
+    sql`SELECT public.lookup_contact_by_invite_token(${surveyId}::uuid, ${inviteToken}::uuid) AS id`,
+  )) as unknown as Array<{ id: string | null }>;
+  const id = result[0]?.id;
+  return id ? { id } : null;
 }
 
 // ========================

--- a/src/app/admin/surveys/[id]/operations/contacts/[contactId]/page.tsx
+++ b/src/app/admin/surveys/[id]/operations/contacts/[contactId]/page.tsx
@@ -56,6 +56,7 @@ export default async function ContactDetailPage({ params }: PageProps) {
           id: detail.contact.id,
           resid: detail.contact.resid,
           attrs: detail.contact.attrs,
+          piiDecrypted: detail.contact.piiDecrypted,
           memo: detail.contact.memo,
           contactMethod: detail.contact.contactMethod,
           respondedAt: detail.contact.respondedAt,

--- a/src/components/operations/contacts/column-scheme-editor.tsx
+++ b/src/components/operations/contacts/column-scheme-editor.tsx
@@ -6,9 +6,10 @@ import { useRouter } from 'next/navigation';
 
 import { updateContactColumns } from '@/actions/contact-actions';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
 import type { ContactColumnDef, ContactColumnScheme } from '@/db/schema/schema-types';
+import { piiFieldLabel } from '@/lib/crypto/pii-fields';
 
 interface ColumnSchemeEditorProps {
   surveyId: string;
@@ -66,7 +67,8 @@ export function ColumnSchemeEditor({ surveyId, scheme }: ColumnSchemeEditorProps
               <th className="px-3 py-2 text-left">순서</th>
               <th className="px-3 py-2 text-left">라벨</th>
               <th className="px-3 py-2 text-left">소스</th>
-              <th className="px-3 py-2 text-center">숨김</th>
+              <th className="px-3 py-2 text-left">개인정보 (암호화)</th>
+              <th className="px-3 py-2 text-center">표시</th>
             </tr>
           </thead>
           <tbody>
@@ -84,9 +86,19 @@ export function ColumnSchemeEditor({ surveyId, scheme }: ColumnSchemeEditorProps
                     <Input value={col.label} onChange={(e) => setLabel(i, e.target.value)} className="h-8 text-sm" />
                   </td>
                   <td className="px-3 py-2 text-xs text-slate-500">{col.source}</td>
+                  <td
+                    className="px-3 py-2 text-xs text-slate-600"
+                    title={col.piiType ? '개인정보 종류는 재업로드로만 변경 가능합니다.' : undefined}
+                  >
+                    {col.piiType ? (
+                      <span>{piiFieldLabel(col.piiType)}</span>
+                    ) : (
+                      <span className="text-slate-300">—</span>
+                    )}
+                  </td>
                   <td className="px-3 py-2 text-center">
-                    <Checkbox
-                      checked={!!col.hidden}
+                    <Switch
+                      checked={!col.hidden}
                       disabled={isResid}
                       onCheckedChange={() => toggleHide(i)}
                     />
@@ -97,6 +109,10 @@ export function ColumnSchemeEditor({ surveyId, scheme }: ColumnSchemeEditorProps
             })}
           </tbody>
         </table>
+      </div>
+
+      <div className="text-xs text-slate-500">
+        개인정보 종류는 업로드 시점에만 결정됩니다. 바꾸려면 명단을 다시 업로드해주세요.
       </div>
 
       <div className="flex gap-2">

--- a/src/components/operations/contacts/contact-detail-form.tsx
+++ b/src/components/operations/contacts/contact-detail-form.tsx
@@ -8,6 +8,7 @@ import {
   deleteContactTarget,
   updateContactColumns,
   updateContactTarget,
+  type PiiUpdate,
 } from '@/actions/contact-actions';
 import { Button } from '@/components/ui/button';
 import { ContactAttemptAddCard } from '@/components/operations/contacts/contact-attempt-add-card';
@@ -20,17 +21,21 @@ import type {
 } from '@/db/schema/schema-types';
 import { useAutoFadeMessage } from '@/hooks/use-auto-fade-message';
 import type { ContactAttemptRow } from '@/lib/operations/contacts.server';
+import { piiKeyOf } from '@/lib/operations/contacts';
+import type { PiiFieldType } from '@/lib/crypto/pii-fields';
 
 interface ContactDetailFormProps {
   surveyId: string;
   scheme: ContactColumnScheme;
   resultCodes: ContactResultCode[];
-  systemFieldKeys?: { group?: string; email?: string; biz?: string };
+  systemFieldKeys?: { group?: string };
   /** 편집 모드: 기존 컨택 정보. 신규 모드: undefined. */
   initial?: {
     id: string;
     resid: number;
     attrs: Record<string, string>;
+    /** PII 컬럼별 복호화 결과 (columnKey → { fieldType, plain, failed }) — RLS 통과 사용자만 접근. */
+    piiDecrypted?: Record<string, { fieldType: string; plain: string; failed: boolean }>;
     memo: string | null;
     contactMethod: ContactMethod | null;
     respondedAt: Date | null;
@@ -50,6 +55,27 @@ export function ContactDetailForm({
   const isEdit = initial != null;
 
   const [attrs, setAttrs] = useState<Record<string, string>>(initial?.attrs ?? {});
+  // PII 값 — columnKey → 평문. 초기값은 piiDecrypted 에서 플랫화 (failed 항목 제외).
+  const initialPiiValues = useMemo<Record<string, string>>(() => {
+    const m: Record<string, string> = {};
+    if (initial?.piiDecrypted) {
+      for (const [k, v] of Object.entries(initial.piiDecrypted)) {
+        if (!v.failed) m[k] = v.plain;
+      }
+    }
+    return m;
+  }, [initial]);
+  // 복호화 실패한 컬럼 set — 편집 금지 + 저장 시 skip 으로 cipher 덮어쓰기 방지.
+  const failedPiiKeys = useMemo<Set<string>>(() => {
+    const s = new Set<string>();
+    if (initial?.piiDecrypted) {
+      for (const [k, v] of Object.entries(initial.piiDecrypted)) {
+        if (v.failed) s.add(k);
+      }
+    }
+    return s;
+  }, [initial]);
+  const [piiValues, setPiiValues] = useState<Record<string, string>>(initialPiiValues);
   const [memo, setMemo] = useState<string | null>(initial?.memo ?? null);
   const [contactMethod, setContactMethod] = useState<ContactMethod | null>(
     initial?.contactMethod ?? null,
@@ -65,14 +91,16 @@ export function ContactDetailForm({
 
   const isDirty = useMemo(() => {
     if (!isEdit) {
-      // 신규 모드: 사용자가 attrs/memo/contactMethod 중 하나라도 입력했으면 dirty.
+      // 신규 모드: 사용자가 attrs/pii/memo/contactMethod 중 하나라도 입력했으면 dirty.
       const hasAttr = Object.values(attrs).some((v) => v && v.trim().length > 0);
+      const hasPii = Object.values(piiValues).some((v) => v && v.trim().length > 0);
       const hasMemo = (memo ?? '').trim().length > 0;
       const hasMethod = contactMethod != null;
-      return hasAttr || hasMemo || hasMethod;
+      return hasAttr || hasPii || hasMemo || hasMethod;
     }
     // 편집 모드: initial 과 비교
     if (!shallowEqualRecord(attrs, initialAttrs)) return true;
+    if (!shallowEqualRecord(piiValues, initialPiiValues)) return true;
     if ((memo ?? '') !== (initialMemo ?? '')) return true;
     if (contactMethod !== initialContactMethod) return true;
     if (!schemeEqual(localScheme, scheme)) return true;
@@ -80,10 +108,12 @@ export function ContactDetailForm({
   }, [
     isEdit,
     attrs,
+    piiValues,
     memo,
     contactMethod,
     localScheme,
     initialAttrs,
+    initialPiiValues,
     initialMemo,
     initialContactMethod,
     scheme,
@@ -131,8 +161,50 @@ export function ContactDetailForm({
     });
   }
 
+  /**
+   * scheme.columns 에서 piiType + columnKey 를 추출. PII 값 변경분과 cross-reference 해
+   * 액션에 보낼 PiiUpdate[] 빌드.
+   */
+  function buildPiiUpdates(): PiiUpdate[] {
+    const updates: PiiUpdate[] = [];
+    for (const col of scheme.columns) {
+      if (!col.piiType) continue;
+      const key = piiKeyOf(col.source);
+      if (!key) continue;
+      // 복호화 실패한 컬럼은 사용자가 수정 못 하므로 저장 대상 아님 — cipher 보존.
+      if (failedPiiKeys.has(key)) continue;
+      const next = piiValues[key] ?? '';
+      const prev = initialPiiValues[key] ?? '';
+      if (next === prev) continue; // 변경 없음 → skip
+      updates.push({
+        columnKey: key,
+        fieldType: col.piiType as PiiFieldType,
+        plain: next,
+      });
+    }
+    return updates;
+  }
+
   function save() {
     setError(null);
+    const piiUpdates = buildPiiUpdates();
+    // 빈 값으로 비운 PII 컬럼은 contact_pii 행이 DELETE 됨 — 복구 불가. confirm 요구.
+    const willDeleteKeys: string[] = [];
+    for (const u of piiUpdates) {
+      if (!u.plain.trim()) {
+        const col = scheme.columns.find((c) => piiKeyOf(c.source) === u.columnKey);
+        willDeleteKeys.push(col?.label ?? u.columnKey);
+      }
+    }
+    if (willDeleteKeys.length > 0) {
+      const ok = window.confirm(
+        `다음 암호화 컬럼이 비어 있어 영구 삭제됩니다 (복구 불가):\n\n· ${willDeleteKeys.join(
+          '\n· ',
+        )}\n\n계속하시겠습니까?`,
+      );
+      if (!ok) return;
+    }
+    const updatesForAction = piiUpdates.length > 0 ? piiUpdates : undefined;
     startTransition(async () => {
       try {
         if (isEdit && initial) {
@@ -140,6 +212,7 @@ export function ContactDetailForm({
             id: initial.id,
             surveyId,
             attrs,
+            piiUpdates: updatesForAction,
             memo,
             contactMethod,
             systemFieldKeys,
@@ -148,6 +221,7 @@ export function ContactDetailForm({
           await addContactTarget({
             surveyId,
             attrs,
+            piiUpdates: updatesForAction,
             memo,
             contactMethod,
             systemFieldKeys,
@@ -172,9 +246,8 @@ export function ContactDetailForm({
   }
 
   // I8: systemFieldKeys 자동 감지 실패 시 안내 banner
-  const systemFieldsMissing =
-    !systemFieldKeys ||
-    (!systemFieldKeys.group && !systemFieldKeys.email && !systemFieldKeys.biz);
+  // (이메일/사업자번호는 contact_pii 사이드 테이블로 이전되어 분류 기준만 남음)
+  const systemFieldsMissing = !systemFieldKeys || !systemFieldKeys.group;
 
   return (
     <div className="space-y-4">
@@ -208,12 +281,15 @@ export function ContactDetailForm({
             resid={initial?.resid ?? null}
             scheme={localScheme}
             attrs={attrs}
+            piiValues={piiValues}
+            failedPiiKeys={failedPiiKeys}
             memo={memo}
             contactMethod={contactMethod}
             respondedAt={initial?.respondedAt ?? null}
             inviteToken={initial?.inviteToken ?? null}
             onColumnToggle={isEdit ? onColumnToggle : undefined}
             onAttrsChange={setAttrs}
+            onPiiChange={(k, v) => setPiiValues((prev) => ({ ...prev, [k]: v }))}
             onMemoChange={(m) => setMemo(m)}
             onContactMethodChange={setContactMethod}
           />

--- a/src/components/operations/contacts/contact-info-card.tsx
+++ b/src/components/operations/contacts/contact-info-card.tsx
@@ -10,14 +10,19 @@ import {
   type ContactColumnScheme,
   type ContactMethod,
 } from '@/db/schema/schema-types';
-import { attrsKeyOf } from '@/lib/operations/contacts';
+import { attrsKeyOf, piiKeyOf } from '@/lib/operations/contacts';
 import { FULL_DATE_FMT } from '@/lib/operations/contacts-shared';
+import { piiFieldLabel, type PiiFieldType } from '@/lib/crypto/pii-fields';
 
 interface ContactInfoCardProps {
   surveyId: string;
   resid: number | null;
   scheme: ContactColumnScheme;
   attrs: Record<string, string>;
+  /** PII 컬럼 현재 값 (columnKey → plain). 편집 가능 — 저장 시 자동 재암호화. */
+  piiValues?: Record<string, string>;
+  /** 복호화 실패한 PII 컬럼 set — readonly 표시 + 편집 금지 (cipher 덮어쓰기 방지). */
+  failedPiiKeys?: ReadonlySet<string>;
   memo: string | null;
   contactMethod: ContactMethod | null;
   respondedAt: Date | null;
@@ -26,30 +31,44 @@ interface ContactInfoCardProps {
   onColumnToggle?: (key: string, hidden: boolean) => void;
   /** attrs 입력 변경 */
   onAttrsChange: (attrs: Record<string, string>) => void;
+  /** PII 컬럼 입력 변경 (columnKey → plain) */
+  onPiiChange?: (columnKey: string, value: string) => void;
   onMemoChange: (memo: string) => void;
   onContactMethodChange: (method: ContactMethod | null) => void;
 }
+
+type InputDef =
+  | { kind: 'attrs'; col: ContactColumnDef; key: string }
+  | { kind: 'pii'; col: ContactColumnDef; key: string; piiType: PiiFieldType };
 
 export function ContactInfoCard({
   surveyId,
   resid,
   scheme,
   attrs,
+  piiValues,
+  failedPiiKeys,
   memo,
   contactMethod,
   respondedAt,
   inviteToken,
   onColumnToggle,
   onAttrsChange,
+  onPiiChange,
   onMemoChange,
   onContactMethodChange,
 }: ContactInfoCardProps) {
-  const inputDefs = scheme.columns
-    .map((c) => ({ col: c, attrsKey: attrsKeyOf(c.source) }))
-    .filter((x): x is { col: ContactColumnDef; attrsKey: string } => x.attrsKey != null)
+  const inputDefs: InputDef[] = scheme.columns
+    .flatMap<InputDef>((c) => {
+      const ak = attrsKeyOf(c.source);
+      if (ak) return [{ kind: 'attrs', col: c, key: ak }];
+      const pk = piiKeyOf(c.source);
+      if (pk && c.piiType) return [{ kind: 'pii', col: c, key: pk, piiType: c.piiType }];
+      return [];
+    })
     .sort((a, b) => a.col.order - b.col.order);
 
-  function setField(attrsKey: string, value: string) {
+  function setAttrsField(attrsKey: string, value: string) {
     onAttrsChange({ ...attrs, [attrsKey]: value });
   }
 
@@ -67,7 +86,7 @@ export function ContactInfoCard({
       <div className="max-h-[60vh] space-y-2 overflow-y-auto px-5 py-4">
         {inputDefs.length === 0 && (
           <div className="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-            표시 가능한 attrs 컬럼이 없습니다.{' '}
+            표시 가능한 컬럼이 없습니다.{' '}
             <a
               href={`/admin/surveys/${surveyId}/operations/contacts/columns`}
               className="underline"
@@ -77,29 +96,57 @@ export function ContactInfoCard({
             에서 헤더를 추가하세요.
           </div>
         )}
-        {inputDefs.map(({ col, attrsKey }, idx) => (
-          <div key={attrsKey} className="flex items-center gap-3">
-            <div className="flex w-40 shrink-0 items-center gap-1 text-xs text-slate-600">
-              <span className="inline-block w-6 rounded bg-slate-100 px-1 text-center text-[10px] text-slate-500 tabular-nums">
-                {idx + 1}
-              </span>
-              <span className="truncate" title={col.label}>{col.label}</span>
-            </div>
-            <Input
-              value={attrs[attrsKey] ?? ''}
-              onChange={(e) => setField(attrsKey, e.target.value)}
-              className="h-9 flex-1"
-            />
-            {onColumnToggle && (
-              <div className="flex shrink-0 items-center gap-1" title="컨택리스트 헤더로 표시">
-                <Switch
-                  checked={!col.hidden}
-                  onCheckedChange={(checked) => onColumnToggle(attrsKey, !checked)}
-                />
+        {inputDefs.map((def, idx) => {
+          const value =
+            def.kind === 'attrs' ? attrs[def.key] ?? '' : piiValues?.[def.key] ?? '';
+          const isFailedPii = def.kind === 'pii' && failedPiiKeys?.has(def.key);
+          const onChange = isFailedPii
+            ? undefined
+            : def.kind === 'attrs'
+              ? (e: React.ChangeEvent<HTMLInputElement>) => setAttrsField(def.key, e.target.value)
+              : (e: React.ChangeEvent<HTMLInputElement>) => onPiiChange?.(def.key, e.target.value);
+          return (
+            <div key={`${def.kind}:${def.key}`} className="flex items-center gap-3">
+              <div className="flex w-40 shrink-0 items-center gap-1 text-xs text-slate-600">
+                <span className="inline-block w-6 rounded bg-slate-100 px-1 text-center text-[10px] text-slate-500 tabular-nums">
+                  {idx + 1}
+                </span>
+                <span className="truncate" title={def.col.label}>
+                  {def.col.label}
+                </span>
               </div>
-            )}
-          </div>
-        ))}
+              <div className="relative flex-1">
+                <Input
+                  value={isFailedPii ? '복호화 실패 — 편집 불가' : value}
+                  onChange={onChange}
+                  readOnly={isFailedPii}
+                  className={`h-9 pr-16 ${isFailedPii ? 'cursor-not-allowed bg-rose-50 text-rose-700' : ''}`}
+                  title={
+                    isFailedPii
+                      ? '암호 키가 바뀌었거나 데이터가 손상되어 복호화할 수 없습니다. 재업로드로 복구 가능.'
+                      : undefined
+                  }
+                />
+                {def.kind === 'pii' && (
+                  <span
+                    className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-slate-400"
+                    title="암호화 저장됨"
+                  >
+                    {piiFieldLabel(def.piiType)}
+                  </span>
+                )}
+              </div>
+              {onColumnToggle && (
+                <div className="flex shrink-0 items-center gap-1" title="컨택리스트 헤더로 표시">
+                  <Switch
+                    checked={!def.col.hidden}
+                    onCheckedChange={(checked) => onColumnToggle(def.key, !checked)}
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
 
         {/* 수신방법 + Web 응답 메타 */}
         <div className="mt-3 rounded bg-slate-50 px-3 py-2">

--- a/src/components/operations/contacts/contacts-table.tsx
+++ b/src/components/operations/contacts/contacts-table.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react';
 import { SortIndicator, TablePagerFooter } from '@/components/operations/table-primitives';
 import type { ContactColumnDef, ContactColumnScheme } from '@/db/schema/schema-types';
 import { useSearchParamsMutator } from '@/hooks/use-search-params-mutator';
-import { attrsKeyOf, type ContactsSortDir, type ContactsSortKey } from '@/lib/operations/contacts';
+import { attrsKeyOf, piiKeyOf, type ContactsSortDir, type ContactsSortKey } from '@/lib/operations/contacts';
 import { SHORT_DATE_FMT } from '@/lib/operations/contacts-shared';
 import type { ContactsRow } from '@/lib/operations/contacts.server';
 
@@ -40,18 +40,30 @@ function sortKeyOf(source: string): ContactsSortKey | null {
  * 컬럼+행 → { display: ReactNode, plain: string | undefined } 한 번 계산.
  * `display` 는 셀 안에 렌더, `plain` 은 td title 에 truncate hover 용으로 사용.
  */
+const PII_DASH = '—';
+
 function computeCell(col: ContactColumnDef, row: ContactsRow): {
   display: React.ReactNode;
   plain: string | undefined;
 } {
   const attrsKey = attrsKeyOf(col.source);
   if (attrsKey) {
-    if (attrsKey === '이메일') return { display: row.emailMasked, plain: row.emailMasked };
-    if (attrsKey === '사업자번호') return { display: row.bizMasked, plain: row.bizMasked };
     const v = row.attrs[attrsKey];
     return v && v !== ''
       ? { display: v, plain: v }
-      : { display: '—', plain: undefined };
+      : { display: PII_DASH, plain: undefined };
+  }
+  const piiKey = piiKeyOf(col.source);
+  if (piiKey) {
+    const hint = row.piiMaskHints[piiKey];
+    if (hint?.maskHint) {
+      // 마스킹 힌트 (예: "naver.com", "5678", "김**")
+      return {
+        display: <span className="text-slate-600">{hint.maskHint}</span>,
+        plain: hint.maskHint,
+      };
+    }
+    return { display: PII_DASH, plain: undefined };
   }
   switch (col.source) {
     case 'system.resid':

--- a/src/components/operations/contacts/upload-wizard.tsx
+++ b/src/components/operations/contacts/upload-wizard.tsx
@@ -17,7 +17,8 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import type { ContactUploadMapping } from '@/db/schema/schema-types';
-import { autoDetectSystemFields } from '@/lib/contacts/auto-detect';
+import { autoDetectPiiMapping, autoDetectSystemFields } from '@/lib/contacts/auto-detect';
+import { type PiiFieldType } from '@/lib/crypto/pii-fields';
 
 type Step = 'file' | 'mapping' | 'result';
 
@@ -28,23 +29,25 @@ interface UploadWizardProps {
 }
 
 interface MappingState {
+  /** 분류 기준 컬럼 인덱스 (선택사항 — null 가능) */
   groupCol: number | null;
-  emailCol: number | null;
-  bizCol: number | null;
-  companyCol: number | null;
-  phoneCol: number | null;
-  /** 컨택리스트에 표시할 attrs 키 set (체크박스 토글 결과) */
+  /** 컨택리스트에 표시할 헤더 set */
   selectedAttrs: Set<string>;
+  /** 사용자 편집 라벨 (헤더명 → 라벨) */
+  labelOverrides: Record<string, string>;
+  /** 헤더명 → PII 타입 매핑 */
+  piiMapping: Record<string, PiiFieldType>;
 }
 
-const initialMapping: MappingState = {
-  groupCol: null,
-  emailCol: null,
-  bizCol: null,
-  companyCol: null,
-  phoneCol: null,
-  selectedAttrs: new Set(),
-};
+const PII_OPTIONS: Array<{ value: PiiFieldType | '_none'; label: string }> = [
+  { value: '_none', label: '없음' },
+  { value: 'email', label: '이메일' },
+  { value: 'mobile', label: '휴대폰' },
+  { value: 'phone', label: '전화' },
+  { value: 'name', label: '이름' },
+  { value: 'address', label: '주소' },
+  { value: 'biz_number', label: '사업자번호' },
+];
 
 export function UploadWizard({ surveyId, existingContactsCount }: UploadWizardProps) {
   const router = useRouter();
@@ -53,7 +56,12 @@ export function UploadWizard({ surveyId, existingContactsCount }: UploadWizardPr
   const [headerRow, setHeaderRow] = useState(2);
   const [sheetName, setSheetName] = useState<string>('');
   const [preview, setPreview] = useState<ParseExcelPreviewResult | null>(null);
-  const [mapping, setMapping] = useState<MappingState>(initialMapping);
+  const [mapping, setMapping] = useState<MappingState>({
+    groupCol: null,
+    selectedAttrs: new Set(),
+    labelOverrides: {},
+    piiMapping: {},
+  });
   const [result, setResult] = useState<{
     uploadedRows: number;
     mergedRows: number;
@@ -72,23 +80,28 @@ export function UploadWizard({ surveyId, existingContactsCount }: UploadWizardPr
         setPreview(r);
         if (!sheetName && r.sheetNames.length > 0) setSheetName(r.sheetNames[0]);
 
-        // 한국어 헤더 자동 감지로 시스템 필드 prefill
         const detected = autoDetectSystemFields(r.headers);
-        setMapping((m) => ({
-          ...m,
-          groupCol: detected.group ?? m.groupCol,
-          emailCol: detected.email ?? m.emailCol,
-          bizCol: detected.biz ?? m.bizCol,
-          phoneCol: detected.phone ?? m.phoneCol,
-          // 디폴트 표시 토글: 자동 감지된 시스템 필드 + 첫 5개 헤더
-          selectedAttrs: new Set([
-            ...r.headers.slice(0, 5),
-            ...(detected.email != null ? [r.headers[detected.email]] : []),
-            ...(detected.biz != null ? [r.headers[detected.biz]] : []),
-            ...(detected.phone != null ? [r.headers[detected.phone]] : []),
-          ]),
-        }));
-        setReplaceConfirmed(false); // 새 파일 업로드마다 reset
+        const piiAuto = autoDetectPiiMapping(r.headers);
+
+        // 디폴트 표시 토글:
+        // - 자동 감지된 PII 컬럼 전부
+        // - 분류 기준
+        // - 그 외 처음 3개 (헤더가 너무 많을 때 시각적 노이즈 방지)
+        const piiHeaders = new Set(Object.keys(piiAuto));
+        const groupHeader = detected.group != null ? r.headers[detected.group] : null;
+        const defaultShown = new Set<string>([
+          ...piiHeaders,
+          ...(groupHeader ? [groupHeader] : []),
+          ...r.headers.filter((h) => !piiHeaders.has(h) && h !== groupHeader).slice(0, 3),
+        ]);
+
+        setMapping({
+          groupCol: detected.group ?? null,
+          selectedAttrs: defaultShown,
+          labelOverrides: {}, // 사용자가 편집한 라벨만. 미편집은 헤더명 그대로 사용.
+          piiMapping: piiAuto,
+        });
+        setReplaceConfirmed(false);
         setStep('mapping');
       } catch (e) {
         setError((e as Error).message);
@@ -97,20 +110,21 @@ export function UploadWizard({ surveyId, existingContactsCount }: UploadWizardPr
   }
 
   async function handleIngest() {
-    if (!file || !preview || mapping.groupCol == null) return;
+    if (!file || !preview) return;
+    if (mapping.selectedAttrs.size === 0) {
+      setError('표시할 컬럼이 없습니다. 최소 한 개는 체크해주세요.');
+      return;
+    }
     setError(null);
     startTransition(async () => {
       try {
         const m: ContactUploadMapping = {
           systemFields: {
-            group: mapping.groupCol!,
-            email: mapping.emailCol ?? undefined,
-            biz: mapping.bizCol ?? undefined,
-            company: mapping.companyCol ?? undefined,
-            phone: mapping.phoneCol ?? undefined,
+            group: mapping.groupCol ?? undefined,
           },
+          piiMapping: mapping.piiMapping,
           selectedAttrsKeys: Array.from(mapping.selectedAttrs),
-          autoDetected: autoDetectSystemFields(preview.headers),
+          labelOverrides: mapping.labelOverrides,
           headerRow,
           sheetName,
         };
@@ -127,12 +141,43 @@ export function UploadWizard({ surveyId, existingContactsCount }: UploadWizardPr
     });
   }
 
+  function updatePii(header: string, value: PiiFieldType | '_none') {
+    setMapping((m) => {
+      const next = { ...m.piiMapping };
+      if (value === '_none') delete next[header];
+      else next[header] = value;
+      return { ...m, piiMapping: next };
+    });
+  }
+
+  function updateLabel(header: string, value: string) {
+    setMapping((m) => {
+      const next = { ...m.labelOverrides };
+      if (value === header || value === '') delete next[header];
+      else next[header] = value;
+      return { ...m, labelOverrides: next };
+    });
+  }
+
+  function toggleShown(header: string, checked: boolean) {
+    setMapping((m) => {
+      const next = new Set(m.selectedAttrs);
+      if (checked) next.add(header);
+      else next.delete(header);
+      return { ...m, selectedAttrs: next };
+    });
+  }
+
+  function setGroupCol(idx: number | null) {
+    setMapping((m) => ({ ...m, groupCol: idx }));
+  }
+
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-base">
           엑셀 컨택 업로드 —{' '}
-          {step === 'file' ? '1/3 파일' : step === 'mapping' ? '2/3 매핑' : '3/3 결과'}
+          {step === 'file' ? '1/3 파일' : step === 'mapping' ? '2/3 컬럼 설정' : '3/3 결과'}
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -200,114 +245,170 @@ export function UploadWizard({ surveyId, existingContactsCount }: UploadWizardPr
               </div>
             )}
 
-            <div className="text-xs text-slate-500">
-              총 {preview.totalRows.toLocaleString('ko-KR')} 행 — 미리보기 5행:
-            </div>
-            <div className="overflow-x-auto rounded border">
-              <table className="w-full text-xs">
-                <thead className="bg-slate-50">
-                  <tr>
-                    {preview.headers.map((h, i) => (
-                      <th key={i} className="border-b px-2 py-1 text-left">
-                        {h}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  {preview.rows.map((row, ri) => (
-                    <tr key={ri}>
-                      {preview.headers.map((h, ci) => (
-                        <td key={ci} className="border-b px-2 py-1">
-                          {row[h]}
-                        </td>
+            {/* 미리보기 (엑셀 첫 5행) */}
+            <div>
+              <div className="mb-1 text-xs text-slate-500">
+                미리보기: 총 {preview.totalRows.toLocaleString('ko-KR')} 행 · 첫 5행
+              </div>
+              <div className="overflow-x-auto rounded border">
+                <table className="w-full text-xs">
+                  <thead className="bg-slate-50">
+                    <tr>
+                      {preview.headers.map((h, i) => (
+                        <th key={i} className="border-b px-2 py-1 text-left whitespace-nowrap">
+                          {h}
+                        </th>
                       ))}
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    {preview.rows.map((row, ri) => (
+                      <tr key={ri}>
+                        {preview.headers.map((h, ci) => (
+                          <td key={ci} className="border-b px-2 py-1 whitespace-nowrap">
+                            {row[h]}
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </div>
 
-            <div className="text-xs text-slate-500 mb-1">
-              시스템 필드 — 그룹은 머지/표시용, 나머지는 PII 마스킹용 (자동 감지됨, 필요 시 수정)
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-              {(['groupCol', 'emailCol', 'bizCol', 'companyCol', 'phoneCol'] as const).map(
-                (field) => {
-                  const labelMap: Record<typeof field, string> = {
-                    groupCol: '그룹 *',
-                    emailCol: '이메일',
-                    bizCol: '사업자번호',
-                    companyCol: '기업명',
-                    phoneCol: '전화',
-                  };
-                  return (
-                    <div key={field} className="flex flex-col gap-1">
-                      <Label className="text-xs">{labelMap[field]}</Label>
-                      <Select
-                        value={mapping[field]?.toString() ?? '_none'}
-                        onValueChange={(v) =>
-                          setMapping((m) => ({
-                            ...m,
-                            [field]: v === '_none' ? null : parseInt(v, 10),
-                          }))
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue placeholder="매핑 안 함" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="_none">매핑 안 함</SelectItem>
-                          {preview.headers.map((h, i) => (
-                            <SelectItem key={i} value={i.toString()}>
-                              {h}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </div>
-                  );
-                },
-              )}
-            </div>
-
+            {/* 컬럼별 설정 매트릭스 */}
             <div>
-              <div className="mb-2 text-xs font-medium text-slate-700">표시할 컬럼 — 컨택리스트에 표시할 헤더 선택</div>
-              <div className="max-h-60 overflow-y-auto rounded border bg-slate-50 p-2">
-                <div className="grid grid-cols-2 gap-1">
-                  {preview.headers.map((h) => (
-                    <label key={h} className="flex items-center gap-2 rounded px-2 py-1 hover:bg-slate-100 text-sm">
-                      <Checkbox
-                        checked={mapping.selectedAttrs.has(h)}
-                        onCheckedChange={(checked) => {
-                          setMapping((m) => {
-                            const next = new Set(m.selectedAttrs);
-                            if (checked) next.add(h);
-                            else next.delete(h);
-                            return { ...m, selectedAttrs: next };
-                          });
-                        }}
-                      />
-                      <span className="truncate" title={h}>{h}</span>
-                    </label>
-                  ))}
-                </div>
-                <div className="mt-2 flex gap-2 border-t pt-2 text-xs">
+              <div className="mb-2 flex items-center justify-between">
+                <div className="text-sm font-medium text-slate-700">엑셀 헤더별 설정</div>
+                <div className="flex gap-3 text-xs">
                   <button
                     type="button"
+                    onClick={() =>
+                      setMapping((m) => ({ ...m, selectedAttrs: new Set(preview.headers) }))
+                    }
                     className="text-blue-600 hover:underline"
-                    onClick={() => setMapping((m) => ({ ...m, selectedAttrs: new Set(preview.headers) }))}
                   >
-                    전체 선택
+                    전체 표시
                   </button>
                   <button
                     type="button"
-                    className="text-slate-500 hover:underline"
                     onClick={() => setMapping((m) => ({ ...m, selectedAttrs: new Set() }))}
+                    className="text-slate-500 hover:underline"
                   >
-                    전체 해제
+                    전체 숨김
                   </button>
-                  <span className="ml-auto text-slate-500">{mapping.selectedAttrs.size}/{preview.headers.length} 선택됨</span>
+                  <span className="text-slate-500">
+                    {mapping.selectedAttrs.size}/{preview.headers.length} 표시
+                  </span>
+                </div>
+              </div>
+              <div className="overflow-hidden rounded border">
+                <table className="w-full table-fixed text-sm">
+                  <colgroup>
+                    <col style={{ width: '28%' }} />
+                    <col />
+                    <col style={{ width: '170px' }} />
+                    <col style={{ width: '60px' }} />
+                    <col style={{ width: '80px' }} />
+                  </colgroup>
+                  <thead className="bg-slate-50 text-xs text-slate-600">
+                    <tr>
+                      <th className="border-b px-3 py-2 text-left font-medium whitespace-nowrap">
+                        엑셀 헤더
+                      </th>
+                      <th className="border-b px-3 py-2 text-left font-medium whitespace-nowrap">
+                        표시 라벨
+                      </th>
+                      <th className="border-b px-3 py-2 text-left font-medium whitespace-nowrap">
+                        개인정보 (암호화)
+                      </th>
+                      <th className="border-b px-3 py-2 text-center font-medium whitespace-nowrap">
+                        표시
+                      </th>
+                      <th className="border-b px-3 py-2 text-center font-medium whitespace-nowrap">
+                        분류 기준
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {preview.headers.map((h, i) => {
+                      const pii = mapping.piiMapping[h];
+                      const labelValue = mapping.labelOverrides[h] ?? h;
+                      const isGroup = mapping.groupCol === i;
+                      const isShown = mapping.selectedAttrs.has(h);
+                      return (
+                        <tr key={h} className="border-t hover:bg-slate-50/50">
+                          <td
+                            className="px-3 py-2 align-middle font-medium text-slate-700"
+                            title={h}
+                          >
+                            <div className="truncate">{h}</div>
+                          </td>
+                          <td className="px-3 py-2 align-middle">
+                            <input
+                              type="text"
+                              value={labelValue}
+                              onChange={(e) => updateLabel(h, e.target.value)}
+                              className="block w-full min-w-0 rounded border px-2 py-1 text-sm"
+                              maxLength={100}
+                              placeholder={h}
+                            />
+                          </td>
+                          <td className="px-3 py-2 align-middle">
+                            <Select
+                              value={pii ?? '_none'}
+                              onValueChange={(v) => updatePii(h, v as PiiFieldType | '_none')}
+                            >
+                              <SelectTrigger className="w-full">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {PII_OPTIONS.map((opt) => (
+                                  <SelectItem key={opt.value} value={opt.value}>
+                                    {opt.label}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                          </td>
+                          <td className="px-3 py-2 text-center align-middle">
+                            <Checkbox
+                              checked={isShown}
+                              onCheckedChange={(checked) => toggleShown(h, checked === true)}
+                            />
+                          </td>
+                          <td className="px-3 py-2 text-center align-middle">
+                            <input
+                              type="radio"
+                              name="group-col"
+                              checked={isGroup}
+                              onChange={() => setGroupCol(i)}
+                              className="h-4 w-4 cursor-pointer"
+                              aria-label={`${h}을(를) 분류 기준으로 사용`}
+                            />
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+              <div className="mt-2 space-y-1 text-xs text-slate-500">
+                <div>개인정보로 지정된 컬럼은 암호화되어 별도 테이블에 저장됩니다.</div>
+                <div>
+                  분류 기준: 같은 값을 가진 행끼리 그룹으로 묶입니다 (예: 전시회명·캠페인명).
+                  {mapping.groupCol != null && (
+                    <>
+                      {' '}
+                      <button
+                        type="button"
+                        onClick={() => setGroupCol(null)}
+                        className="text-blue-600 hover:underline"
+                      >
+                        선택 해제
+                      </button>
+                    </>
+                  )}
                 </div>
               </div>
             </div>
@@ -320,6 +421,7 @@ export function UploadWizard({ surveyId, existingContactsCount }: UploadWizardPr
                 <ul className="ml-4 list-disc space-y-1 text-red-700">
                   <li>기존 컨택 행 모두 삭제 후 신규 명단으로 교체</li>
                   <li>각 컨택의 회차 기록 (contact_attempts) 도 함께 삭제됨</li>
+                  <li>각 컨택의 암호화된 개인정보도 함께 삭제됨</li>
                   <li>이미 발송된 초대 링크 모두 무효화</li>
                   <li>응답 본체는 보존되지만 컨택 매칭이 끊겨 익명 응답으로 표시됨</li>
                 </ul>
@@ -334,20 +436,13 @@ export function UploadWizard({ surveyId, existingContactsCount }: UploadWizardPr
             )}
 
             <Button
-              disabled={
-                mapping.groupCol == null ||
-                isPending ||
-                (existingContactsCount > 0 && !replaceConfirmed)
-              }
+              disabled={isPending || (existingContactsCount > 0 && !replaceConfirmed)}
               onClick={handleIngest}
             >
               {isPending
                 ? '적재 중…'
                 : `${preview.totalRows.toLocaleString('ko-KR')} 행 적재 시작`}
             </Button>
-            {mapping.groupCol == null && (
-              <div className="text-xs text-amber-700">그룹 컬럼은 필수입니다.</div>
-            )}
           </div>
         )}
 

--- a/src/db/schema/contacts.ts
+++ b/src/db/schema/contacts.ts
@@ -27,8 +27,6 @@ export const contactTargets = pgTable(
       .references(() => surveys.id, { onDelete: 'cascade' }),
     resid: integer('resid').notNull(),
     groupValue: text('group_value'),
-    email: text('email'),
-    bizNumber: text('biz_number'),
     inviteToken: uuid('invite_token').defaultRandom().notNull(),
     attrs: jsonb('attrs').$type<Record<string, string>>().notNull().default({}),
     uploadId: uuid('upload_id').references(() => contactUploads.id, { onDelete: 'set null' }),
@@ -42,6 +40,28 @@ export const contactTargets = pgTable(
   (table) => ({
     surveyResidUnique: unique('contact_targets_survey_resid_unique').on(table.surveyId, table.resid),
     inviteTokenUnique: unique('contact_targets_invite_token_unique').on(table.inviteToken),
+  }),
+);
+
+export const contactPii = pgTable(
+  'contact_pii',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    contactTargetId: uuid('contact_target_id')
+      .notNull()
+      .references(() => contactTargets.id, { onDelete: 'cascade' }),
+    fieldType: text('field_type').notNull(),
+    columnKey: text('column_key').notNull(),
+    cipher: text('cipher').notNull(),
+    blindIndex: text('blind_index').notNull(),
+    maskHint: text('mask_hint'),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    targetColumnUnique: unique('contact_pii_target_column_unique').on(
+      table.contactTargetId,
+      table.columnKey,
+    ),
   }),
 );
 
@@ -87,6 +107,14 @@ export const contactTargetsRelations = relations(contactTargets, ({ one, many })
     references: [surveyResponses.id],
   }),
   attempts: many(contactAttempts),
+  pii: many(contactPii),
+}));
+
+export const contactPiiRelations = relations(contactPii, ({ one }) => ({
+  target: one(contactTargets, {
+    fields: [contactPii.contactTargetId],
+    references: [contactTargets.id],
+  }),
 }));
 
 export const contactAttemptsRelations = relations(contactAttempts, ({ one }) => ({
@@ -114,3 +142,5 @@ export type ContactTarget = typeof contactTargets.$inferSelect;
 export type NewContactTarget = typeof contactTargets.$inferInsert;
 export type ContactAttempt = typeof contactAttempts.$inferSelect;
 export type NewContactAttempt = typeof contactAttempts.$inferInsert;
+export type ContactPii = typeof contactPii.$inferSelect;
+export type NewContactPii = typeof contactPii.$inferInsert;

--- a/src/db/schema/schema-types.ts
+++ b/src/db/schema/schema-types.ts
@@ -269,10 +269,16 @@ export interface ContactColumnDef {
     | 'system.contact_result'
     | 'system.email_count'
     | 'system.web'
-    | 'system.contact_owner';
+    | 'system.contact_owner'
+    | `pii.${string}`;
   order: number;
   /** 숨김 (운영 컬럼 일부는 hide 불가 — UI 가드) */
   hidden?: boolean;
+  /**
+   * PII 매핑 타입. 지정되면 해당 엑셀 컬럼 값이 contact_pii 사이드 테이블에
+   * 암호화 저장되고, attrs 에는 저장되지 않는다. 사후 변경 불가 — 재업로드 필요.
+   */
+  piiType?: import('@/lib/crypto/pii-fields').PiiFieldType;
 }
 
 /** surveys.progress_columns — 진척률 표 (Report 탭) 그룹 메타 컬럼 픽커 */
@@ -292,24 +298,19 @@ export interface ProgressColumnDef {
 
 /** contact_uploads.mapping — 엑셀 업로드 매핑 결과 (시나리오 B 단순화) */
 export interface ContactUploadMapping {
-  /** 시스템 필드 → 엑셀 0-based 컬럼 인덱스. group 만 필수. */
+  /** 시스템 필드 → 엑셀 0-based 컬럼 인덱스. group 만 사용 (미지정 시 단일 명단 취급). */
   systemFields: {
-    group: number;
-    email?: number;
-    biz?: number;
-    name?: number;
-    company?: number;
-    phone?: number;
-  };
-  /** 사용자가 컨택리스트에 표시하기로 토글한 attrs 키 (헤더명) 목록. 나머지는 hidden 으로 자동 등록. */
-  selectedAttrsKeys: string[];
-  /** 자동 감지된 시스템 필드 (UI 표시용 — 사용자가 수동 조정 가능). */
-  autoDetected?: {
-    email?: number;
-    biz?: number;
-    phone?: number;
     group?: number;
   };
+  /**
+   * 엑셀 헤더 → PII 타입 매핑. 키는 엑셀 헤더(원본 컬럼명), 값은 PII 타입.
+   * 매핑된 컬럼은 contact_pii 사이드 테이블에 암호화 저장, attrs 에는 저장 안 함.
+   */
+  piiMapping?: Record<string, import('@/lib/crypto/pii-fields').PiiFieldType>;
+  /** 사용자가 컨택리스트에 표시하기로 토글한 attrs 키 (헤더명) 목록. 나머지는 hidden 으로 자동 등록. */
+  selectedAttrsKeys: string[];
+  /** 사용자가 편집한 표시 라벨 (헤더명 → 라벨). 미지정 헤더는 헤더명 그대로. */
+  labelOverrides?: Record<string, string>;
   /** 1-based, 디폴트 1 */
   headerRow: number;
   /** 사용자가 선택한 시트 이름 (디폴트 첫 시트) */

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -3,6 +3,8 @@ import * as Sentry from '@sentry/nextjs';
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     await import('../sentry.server.config');
+    const { assertCryptoEnv } = await import('./lib/crypto/env');
+    assertCryptoEnv();
   }
 
   if (process.env.NEXT_RUNTIME === 'edge') {

--- a/src/lib/contacts/auto-detect.ts
+++ b/src/lib/contacts/auto-detect.ts
@@ -1,21 +1,23 @@
 /**
- * 엑셀 헤더 (정규화된 한국어) → 시스템 필드 자동 매칭.
+ * 엑셀 헤더 (정규화된 한국어) → 시스템 필드 + PII 타입 자동 매칭.
  * 우선순위: 정확 매칭 > 부분 포함.
  *
  * 단위 테스트: tests/unit/domains/contacts/auto-detect.test.ts.
  */
 
+import type { PiiFieldType } from '@/lib/crypto/pii-fields';
+
 const PATTERNS = {
-  email: ['이메일', '메일', 'email', 'e-mail'],
+  email: ['이메일', '메일', 'email', 'e-mail', '메일주소'],
   biz: ['사업자등록번호', '사업자번호', '사업자', 'biz'],
-  phone: ['휴대폰번호', '핸드폰', '휴대폰', '전화번호', '전화', 'phone', 'mobile'],
+  mobile: ['휴대폰번호', '휴대폰', '핸드폰', '모바일', 'mobile', 'cell'],
+  phone: ['전화번호', '전화', '유선', '연락처', 'phone', 'tel'],
+  name: ['이름', '성명', '담당자', 'name', 'contact name'],
+  address: ['주소', '소재지', 'address'],
   group: ['전시회명', '전시회', '캠페인'],
 } as const;
 
 export interface AutoDetected {
-  email?: number;
-  biz?: number;
-  phone?: number;
   group?: number;
 }
 
@@ -33,13 +35,55 @@ function findHeader(headers: string[], patterns: readonly string[]): number | un
 
 export function autoDetectSystemFields(headers: string[]): AutoDetected {
   const result: AutoDetected = {};
-  const email = findHeader(headers, PATTERNS.email);
-  if (email != null) result.email = email;
-  const biz = findHeader(headers, PATTERNS.biz);
-  if (biz != null) result.biz = biz;
-  const phone = findHeader(headers, PATTERNS.phone);
-  if (phone != null) result.phone = phone;
   const group = findHeader(headers, PATTERNS.group);
   if (group != null) result.group = group;
+  return result;
+}
+
+/**
+ * 헤더 한 줄을 보고 PII 타입을 추정. 매칭 없으면 undefined.
+ * mobile 패턴이 phone 패턴보다 먼저 검사돼야 "휴대폰" 이 phone 으로 떨어지지 않음.
+ */
+export function detectPiiType(header: string): PiiFieldType | undefined {
+  const h = header.trim();
+  if (!h) return undefined;
+  // 정확 매칭 우선
+  for (const [type, patterns] of (
+    [
+      ['email', PATTERNS.email],
+      ['biz_number', PATTERNS.biz],
+      ['mobile', PATTERNS.mobile],
+      ['phone', PATTERNS.phone],
+      ['name', PATTERNS.name],
+      ['address', PATTERNS.address],
+    ] as const
+  )) {
+    if (patterns.some((p) => p === h)) return type;
+  }
+  // 부분 포함
+  for (const [type, patterns] of (
+    [
+      ['email', PATTERNS.email],
+      ['biz_number', PATTERNS.biz],
+      ['mobile', PATTERNS.mobile],
+      ['phone', PATTERNS.phone],
+      ['name', PATTERNS.name],
+      ['address', PATTERNS.address],
+    ] as const
+  )) {
+    if (patterns.some((p) => h.includes(p))) return type;
+  }
+  return undefined;
+}
+
+/**
+ * 헤더 배열 → PII 매핑 자동 prefill. 사용자가 검토·수정 가능.
+ */
+export function autoDetectPiiMapping(headers: string[]): Record<string, PiiFieldType> {
+  const result: Record<string, PiiFieldType> = {};
+  for (const h of headers) {
+    const t = detectPiiType(h);
+    if (t) result[h] = t;
+  }
   return result;
 }

--- a/src/lib/contacts/scheme-helpers.ts
+++ b/src/lib/contacts/scheme-helpers.ts
@@ -1,0 +1,47 @@
+import 'server-only';
+import { eq } from 'drizzle-orm';
+
+import { db } from '@/db';
+import { surveys } from '@/db/schema';
+import type { ContactColumnScheme } from '@/db/schema/schema-types';
+import { piiKeyOf } from '@/lib/operations/contacts';
+
+/**
+ * surveys.contactColumns 에서 PII 로 마킹된 컬럼의 column_key set 을 추출.
+ * 스킴이 없거나 PII 컬럼이 없으면 빈 set 반환.
+ */
+function collectPiiKeys(scheme: ContactColumnScheme | null): Set<string> {
+  const keys = new Set<string>();
+  if (!scheme) return keys;
+  for (const c of scheme.columns) {
+    if (!c.piiType) continue;
+    const k = piiKeyOf(c.source);
+    if (k) keys.add(k);
+  }
+  return keys;
+}
+
+/**
+ * 컬럼 스킴에 PII 로 마킹된 컬럼 key 를 attrs 에서 제거.
+ * UI 우회 (직접 API 호출) 시 PII 가 attrs JSONB 에 평문 누적되는 것을 차단하는 방어 레이어.
+ *
+ * 호출 비용: surveys 조회 1회. addContactTarget / updateContactTarget 진입점에서 사용.
+ */
+export async function sanitizeAttrsAgainstPii(
+  surveyId: string,
+  attrs: Record<string, string>,
+): Promise<Record<string, string>> {
+  const [row] = await db
+    .select({ contactColumns: surveys.contactColumns })
+    .from(surveys)
+    .where(eq(surveys.id, surveyId))
+    .limit(1);
+  const scheme = (row?.contactColumns as ContactColumnScheme | null) ?? null;
+  const piiKeys = collectPiiKeys(scheme);
+  if (piiKeys.size === 0) return attrs;
+  const clean: Record<string, string> = {};
+  for (const [k, v] of Object.entries(attrs)) {
+    if (!piiKeys.has(k)) clean[k] = v;
+  }
+  return clean;
+}

--- a/src/lib/crypto/aes.ts
+++ b/src/lib/crypto/aes.ts
@@ -1,0 +1,86 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createSecretKey,
+  randomBytes,
+  type KeyObject,
+} from 'node:crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+const TAG_LENGTH = 16;
+
+/**
+ * 키 버전 dispatch — token prefix 로 버전 식별 후 적절한 env 키 사용.
+ *
+ * 새 키 도입 절차:
+ *  1. CONTACT_PII_AES_KEY_V2 env 추가 (운영 secrets)
+ *  2. 아래 KEY_ENV_MAP 에 'v2' 등록
+ *  3. ACTIVE_VERSION 을 'v2' 로 변경 → 신규 암호화는 v2
+ *  4. 백그라운드 잡으로 기존 v1 cipher 복호화 후 v2 로 재암호화
+ *  5. 모든 데이터 마이그레이션 완료 후 'v1' 항목 제거 + env 정리
+ *
+ * 복호화는 token 의 prefix 를 보고 자동으로 해당 버전 키 사용 — dual-decrypt.
+ */
+const KEY_ENV_MAP: Record<string, string> = {
+  v1: 'CONTACT_PII_AES_KEY',
+  // v2: 'CONTACT_PII_AES_KEY_V2',  // 키 로테이션 시 활성화
+};
+
+/** 신규 암호화에 사용할 버전. */
+const ACTIVE_VERSION = 'v1';
+
+// Node 22 의 @types/node 가 Buffer<ArrayBufferLike> vs Uint8Array<ArrayBuffer> 를 구분해
+// createCipheriv 에 Buffer 직접 전달 시 타입 에러가 발생. KeyObject 로 한 번 감싸 우회.
+function getKeyForVersion(version: string): KeyObject {
+  const envName = KEY_ENV_MAP[version];
+  if (!envName) {
+    throw new Error(`decryptPii: unsupported key version "${version}"`);
+  }
+  const raw = process.env[envName];
+  if (!raw) {
+    throw new Error(`${envName} env required (base64 32 bytes)`);
+  }
+  const key = Buffer.from(raw, 'base64');
+  if (key.length !== 32) {
+    throw new Error(`${envName} must decode to 32 bytes (got ${key.length})`);
+  }
+  return createSecretKey(new Uint8Array(key));
+}
+
+function toU8(b: Buffer | Uint8Array): Uint8Array {
+  return b instanceof Uint8Array && !(b instanceof Buffer) ? b : new Uint8Array(b);
+}
+
+export function encryptPii(plain: string): string {
+  const iv = new Uint8Array(randomBytes(IV_LENGTH));
+  const cipher = createCipheriv(ALGORITHM, getKeyForVersion(ACTIVE_VERSION), iv);
+  const enc = Buffer.concat([toU8(cipher.update(plain, 'utf8')), toU8(cipher.final())]);
+  const tag = cipher.getAuthTag();
+  const payload = Buffer.concat([iv, toU8(tag), toU8(enc)]).toString('base64');
+  return `${ACTIVE_VERSION}:${payload}`;
+}
+
+export function decryptPii(token: string): string {
+  const sep = token.indexOf(':');
+  if (sep < 0) {
+    throw new Error('decryptPii: missing key version prefix');
+  }
+  const version = token.slice(0, sep);
+  const payload = token.slice(sep + 1);
+  if (!payload) {
+    throw new Error('decryptPii: empty payload');
+  }
+  const buf = Buffer.from(payload, 'base64');
+  if (buf.length < IV_LENGTH + TAG_LENGTH) {
+    throw new Error('decryptPii: payload too short');
+  }
+  const iv = new Uint8Array(buf.subarray(0, IV_LENGTH));
+  const tag = new Uint8Array(buf.subarray(IV_LENGTH, IV_LENGTH + TAG_LENGTH));
+  const enc = new Uint8Array(buf.subarray(IV_LENGTH + TAG_LENGTH));
+  // version 에 따라 자동으로 해당 키 사용 → 키 로테이션 기간에도 옛 cipher 복호화 가능
+  const decipher = createDecipheriv(ALGORITHM, getKeyForVersion(version), iv);
+  decipher.setAuthTag(tag);
+  const dec = Buffer.concat([toU8(decipher.update(enc)), toU8(decipher.final())]);
+  return dec.toString('utf8');
+}

--- a/src/lib/crypto/blind.ts
+++ b/src/lib/crypto/blind.ts
@@ -1,0 +1,22 @@
+import { createHmac, createSecretKey, type KeyObject } from 'node:crypto';
+import { normalizePii, type PiiFieldType } from './pii-fields';
+
+function getKey(): KeyObject {
+  const raw = process.env.CONTACT_PII_HMAC_KEY;
+  if (!raw) {
+    throw new Error('CONTACT_PII_HMAC_KEY env required (base64 32 bytes)');
+  }
+  const key = Buffer.from(raw, 'base64');
+  if (key.length !== 32) {
+    throw new Error(`CONTACT_PII_HMAC_KEY must decode to 32 bytes (got ${key.length})`);
+  }
+  return createSecretKey(new Uint8Array(key));
+}
+
+export function blindIndex(fieldType: PiiFieldType, value: string): string {
+  const normalized = normalizePii(fieldType, value);
+  if (!normalized) return '';
+  const hmac = createHmac('sha256', getKey());
+  hmac.update(`${fieldType}:${normalized}`);
+  return hmac.digest('hex');
+}

--- a/src/lib/crypto/contact-pii-repo.ts
+++ b/src/lib/crypto/contact-pii-repo.ts
@@ -1,0 +1,253 @@
+import { and, eq, inArray, or } from 'drizzle-orm';
+
+import { db } from '@/db';
+import { contactPii, contactTargets, type NewContactPii } from '@/db/schema';
+
+import { decryptPii, encryptPii } from './aes';
+import { blindIndex } from './blind';
+import { maskHint } from './mask-hint';
+import { type PiiFieldType } from './pii-fields';
+
+export interface PiiInput {
+  columnKey: string;
+  fieldType: PiiFieldType;
+  plain: string;
+}
+
+/**
+ * PII 입력값들을 contact_pii 행으로 변환. 빈 값/정규화 후 빈 값은 자동으로 스킵.
+ * cipher 는 원본값, blind_index 는 정규화 값 기준이라 검색 시 대소문자·구분자 차이 흡수.
+ */
+export function buildPiiRows(
+  contactTargetId: string,
+  inputs: readonly PiiInput[],
+): NewContactPii[] {
+  const rows: NewContactPii[] = [];
+  for (const input of inputs) {
+    const trimmed = input.plain.trim();
+    if (!trimmed) continue;
+    const blind = blindIndex(input.fieldType, trimmed);
+    if (!blind) continue; // 정규화 후 빈 값 (예: 전화번호에 숫자가 없음)
+    rows.push({
+      contactTargetId,
+      fieldType: input.fieldType,
+      columnKey: input.columnKey,
+      cipher: encryptPii(trimmed),
+      blindIndex: blind,
+      maskHint: maskHint(input.fieldType, trimmed),
+    });
+  }
+  return rows;
+}
+
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * 트랜잭션 내에서 contact_pii batch insert. UNIQUE (target_id, column_key) 충돌은 무시.
+ */
+export async function insertPiiRows(tx: Tx, rows: readonly NewContactPii[]): Promise<void> {
+  if (rows.length === 0) return;
+  await tx.insert(contactPii).values([...rows]).onConflictDoNothing();
+}
+
+
+/**
+ * 여러 contact 의 mask_hint 만 일괄 조회. cipher 는 가져오지 않아 비용 낮음.
+ * 반환: targetId → columnKey → { fieldType, maskHint }
+ */
+export async function getMaskHintsForTargets(
+  targetIds: readonly string[],
+): Promise<Map<string, Record<string, { fieldType: PiiFieldType; maskHint: string | null }>>> {
+  const result = new Map<
+    string,
+    Record<string, { fieldType: PiiFieldType; maskHint: string | null }>
+  >();
+  if (targetIds.length === 0) return result;
+
+  const rows = await db
+    .select({
+      contactTargetId: contactPii.contactTargetId,
+      fieldType: contactPii.fieldType,
+      columnKey: contactPii.columnKey,
+      maskHint: contactPii.maskHint,
+    })
+    .from(contactPii)
+    .where(inArray(contactPii.contactTargetId, [...targetIds]));
+
+  for (const r of rows) {
+    const existing = result.get(r.contactTargetId) ?? {};
+    existing[r.columnKey] = {
+      fieldType: r.fieldType as PiiFieldType,
+      maskHint: r.maskHint,
+    };
+    result.set(r.contactTargetId, existing);
+  }
+  return result;
+}
+
+export interface DecryptedPii {
+  fieldType: PiiFieldType;
+  /** 복호화 성공 시 평문, 실패 시 빈 문자열 (UI 가 failed 플래그를 보고 처리해야 함). */
+  plain: string;
+  /** 복호화 실패 여부 — true 면 UI 는 readonly 표시 + 저장 시 skip. cipher 덮어쓰기 방지. */
+  failed: boolean;
+}
+
+/**
+ * 단일 contact 의 PII 전체 복호화. 권한 확인 후에만 호출.
+ * 반환: columnKey → DecryptedPii. failed=true 인 항목은 UI 가 readonly 처리해서
+ * 사용자가 의도치 않게 새 cipher 로 덮어쓰지 않도록 해야 함.
+ */
+export async function decryptForTarget(
+  targetId: string,
+): Promise<Record<string, DecryptedPii>> {
+  const rows = await db
+    .select({
+      fieldType: contactPii.fieldType,
+      columnKey: contactPii.columnKey,
+      cipher: contactPii.cipher,
+    })
+    .from(contactPii)
+    .where(eq(contactPii.contactTargetId, targetId));
+
+  const result: Record<string, DecryptedPii> = {};
+  for (const r of rows) {
+    let plain = '';
+    let failed = false;
+    try {
+      plain = decryptPii(r.cipher);
+    } catch {
+      failed = true;
+    }
+    result[r.columnKey] = {
+      fieldType: r.fieldType as PiiFieldType,
+      plain,
+      failed,
+    };
+  }
+  return result;
+}
+
+/**
+ * 단건 PII 값 UPSERT (트랜잭션 내).
+ * - 빈 값/정규화 후 빈 값 → 기존 행 DELETE
+ * - 값 있음 → INSERT or UPDATE (UNIQUE target_id, column_key)
+ * cipher/blind_index/mask_hint 모두 새 값으로 재계산.
+ */
+export async function upsertPiiValue(
+  tx: Tx,
+  contactTargetId: string,
+  columnKey: string,
+  fieldType: PiiFieldType,
+  plain: string,
+): Promise<void> {
+  const trimmed = plain.trim();
+  if (!trimmed) {
+    await tx
+      .delete(contactPii)
+      .where(
+        and(
+          eq(contactPii.contactTargetId, contactTargetId),
+          eq(contactPii.columnKey, columnKey),
+        ),
+      );
+    return;
+  }
+
+  const blind = blindIndex(fieldType, trimmed);
+  if (!blind) {
+    // 정규화 후 빈 값 (예: 전화번호에 숫자가 없음)
+    await tx
+      .delete(contactPii)
+      .where(
+        and(
+          eq(contactPii.contactTargetId, contactTargetId),
+          eq(contactPii.columnKey, columnKey),
+        ),
+      );
+    return;
+  }
+
+  const cipher = encryptPii(trimmed);
+  const hint = maskHint(fieldType, trimmed);
+
+  await tx
+    .insert(contactPii)
+    .values({
+      contactTargetId,
+      fieldType,
+      columnKey,
+      cipher,
+      blindIndex: blind,
+      maskHint: hint,
+    })
+    .onConflictDoUpdate({
+      target: [contactPii.contactTargetId, contactPii.columnKey],
+      set: {
+        fieldType,
+        cipher,
+        blindIndex: blind,
+        maskHint: hint,
+      },
+    });
+}
+
+/**
+ * 단일 (fieldType, plainValue) 정확 매치 검색. surveyId 범위로 한정.
+ * 반환: 매칭된 contact_target_id 목록.
+ */
+export async function findContactIdsByBlindIndex(
+  surveyId: string,
+  fieldType: PiiFieldType,
+  plainValue: string,
+): Promise<string[]> {
+  const blind = blindIndex(fieldType, plainValue);
+  if (!blind) return [];
+
+  const rows = await db
+    .select({ targetId: contactPii.contactTargetId })
+    .from(contactPii)
+    .innerJoin(contactTargets, eq(contactTargets.id, contactPii.contactTargetId))
+    .where(
+      and(
+        eq(contactTargets.surveyId, surveyId),
+        eq(contactPii.fieldType, fieldType),
+        eq(contactPii.blindIndex, blind),
+      ),
+    );
+  return rows.map((r) => r.targetId);
+}
+
+/**
+ * 한 plain 값을 여러 fieldType 으로 동시에 검색 — 'all' 통합검색용.
+ * 각 fieldType 별 blind_index 미리 계산 → 단일 SQL 로 OR 매치.
+ * 6번의 round-trip 을 1번으로 줄이는 최적화.
+ */
+export async function findContactIdsByPlainAcrossTypes(
+  surveyId: string,
+  fieldTypes: readonly PiiFieldType[],
+  plainValue: string,
+): Promise<string[]> {
+  if (fieldTypes.length === 0) return [];
+
+  // 각 타입별 blind_index 계산 — 정규화 후 빈 값인 케이스는 제외.
+  const pairs: Array<{ fieldType: PiiFieldType; blind: string }> = [];
+  for (const t of fieldTypes) {
+    const blind = blindIndex(t, plainValue);
+    if (blind) pairs.push({ fieldType: t, blind });
+  }
+  if (pairs.length === 0) return [];
+
+  // OR (field_type=? AND blind_index=?) 들의 합집합. (field_type, blind_index) 인덱스 활용.
+  const orClauses = pairs.map((p) =>
+    and(eq(contactPii.fieldType, p.fieldType), eq(contactPii.blindIndex, p.blind)),
+  );
+  const combinedOr = pairs.length === 1 ? orClauses[0] : or(...orClauses);
+
+  const rows = await db
+    .select({ targetId: contactPii.contactTargetId })
+    .from(contactPii)
+    .innerJoin(contactTargets, eq(contactTargets.id, contactPii.contactTargetId))
+    .where(and(eq(contactTargets.surveyId, surveyId), combinedOr));
+  return Array.from(new Set(rows.map((r) => r.targetId)));
+}

--- a/src/lib/crypto/env.ts
+++ b/src/lib/crypto/env.ts
@@ -1,0 +1,22 @@
+const REQUIRED_KEY_BYTES = 32;
+
+function assertKey(envName: string, optional = false): void {
+  const raw = process.env[envName];
+  if (!raw) {
+    if (optional) return;
+    throw new Error(`${envName} env required (base64 ${REQUIRED_KEY_BYTES} bytes)`);
+  }
+  const decoded = Buffer.from(raw, 'base64');
+  if (decoded.length !== REQUIRED_KEY_BYTES) {
+    throw new Error(
+      `${envName} must decode to ${REQUIRED_KEY_BYTES} bytes (got ${decoded.length})`,
+    );
+  }
+}
+
+export function assertCryptoEnv(): void {
+  assertKey('CONTACT_PII_AES_KEY');
+  assertKey('CONTACT_PII_HMAC_KEY');
+  // 키 로테이션 진행 중일 때만 활성화. 평시엔 미설정 OK.
+  assertKey('CONTACT_PII_AES_KEY_V2', true);
+}

--- a/src/lib/crypto/mask-hint.ts
+++ b/src/lib/crypto/mask-hint.ts
@@ -1,0 +1,65 @@
+import type { PiiFieldType } from './pii-fields';
+
+/**
+ * 컨택 목록의 PII 마스킹 표시. 앞부분만 노출하고 뒤는 "..." 으로 가린다.
+ * - email: 'asd...@nav...' (local 앞 3 + domain 앞 3)
+ * - mobile (010-): '010-22...' (앞 5자리)
+ * - phone (일반): '02-345...' / '031-555...' (앞 6자리)
+ * - biz_number: '123-45...' (앞 5자리, 표준 XXX-XX-XXXXX 형식 일부)
+ * - name / representative: '김**' (첫 글자 + ** )
+ * - address: '서울특별시' (첫 단어)
+ */
+export function maskHint(fieldType: PiiFieldType, value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  switch (fieldType) {
+    case 'email': {
+      const at = trimmed.lastIndexOf('@');
+      if (at <= 0 || at === trimmed.length - 1) return '';
+      const local = trimmed.slice(0, at);
+      const domain = trimmed.slice(at + 1).toLowerCase();
+      const localShown = local.slice(0, Math.min(3, local.length));
+      const dotIdx = domain.indexOf('.');
+      const domainHead = dotIdx > 0 ? domain.slice(0, dotIdx) : domain;
+      const domainShown = domainHead.slice(0, Math.min(3, domainHead.length));
+      return `${localShown}...@${domainShown}...`;
+    }
+    case 'mobile': {
+      const digits = trimmed.replace(/[^0-9]/g, '');
+      if (digits.length < 5) return '';
+      if (digits.startsWith('010') && digits.length === 11) {
+        return `010-${digits.slice(3, 5)}...`;
+      }
+      // 011/016/017/018/019 류
+      return `${digits.slice(0, 3)}-${digits.slice(3, 5)}...`;
+    }
+    case 'phone': {
+      const digits = trimmed.replace(/[^0-9]/g, '');
+      if (digits.length < 5) return '';
+      // 02-XXX... (서울)
+      if (digits.startsWith('02') && digits.length >= 9) {
+        return `02-${digits.slice(2, 5)}...`;
+      }
+      // 0XX-XXX... (지역번호 3자리)
+      if (digits.length >= 10) {
+        return `${digits.slice(0, 3)}-${digits.slice(3, 6)}...`;
+      }
+      return `${digits.slice(0, 5)}...`;
+    }
+    case 'biz_number': {
+      const digits = trimmed.replace(/[^0-9]/g, '');
+      if (digits.length < 5) return '';
+      // 표준 XXX-XX-XXXXX → 앞 5자리(XXX-XX) 노출
+      return `${digits.slice(0, 3)}-${digits.slice(3, 5)}...`;
+    }
+    case 'name':
+    case 'representative': {
+      const first = [...trimmed][0];
+      return first ? `${first}**` : '';
+    }
+    case 'address': {
+      const first = trimmed.split(/\s+/)[0];
+      return first ?? '';
+    }
+  }
+}

--- a/src/lib/crypto/pii-fields.ts
+++ b/src/lib/crypto/pii-fields.ts
@@ -1,0 +1,54 @@
+export const PII_FIELD_TYPES = [
+  'email',
+  'mobile',
+  'phone',
+  'name',
+  'representative',
+  'biz_number',
+  'address',
+] as const;
+
+export type PiiFieldType = (typeof PII_FIELD_TYPES)[number];
+
+export function isPiiFieldType(value: string): value is PiiFieldType {
+  return (PII_FIELD_TYPES as readonly string[]).includes(value);
+}
+
+/** PII 타입 → 사용자 표시용 한국어 라벨. UI 컴포넌트는 이 한 곳만 참조. */
+export const PII_LABEL_KO: Record<PiiFieldType, string> = {
+  email: '이메일',
+  mobile: '휴대폰',
+  phone: '전화',
+  name: '이름',
+  representative: '담당자',
+  address: '주소',
+  biz_number: '사업자번호',
+};
+
+export function piiFieldLabel(t: PiiFieldType): string {
+  return PII_LABEL_KO[t] ?? t;
+}
+
+export function normalizePii(fieldType: PiiFieldType, value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  switch (fieldType) {
+    case 'email': {
+      // 최소 형식 검증: local@domain (각각 1자 이상)
+      const lower = trimmed.toLowerCase();
+      const at = lower.indexOf('@');
+      if (at <= 0 || at === lower.length - 1) return '';
+      // domain 에 점 없으면 사실상 무효 (TLD 없음) — blind_index 생성 안 함
+      if (!lower.slice(at + 1).includes('.')) return '';
+      return lower;
+    }
+    case 'mobile':
+    case 'phone':
+    case 'biz_number':
+      return trimmed.replace(/[^0-9]/g, '');
+    case 'name':
+    case 'representative':
+    case 'address':
+      return trimmed.replace(/\s+/g, ' ');
+  }
+}

--- a/src/lib/operations/contacts-shared.ts
+++ b/src/lib/operations/contacts-shared.ts
@@ -17,16 +17,12 @@ import type { ContactColumnScheme, ContactResultCode } from '@/db/schema/schema-
 
 export interface SystemFieldKeys {
   group?: string;
-  email?: string;
-  biz?: string;
 }
 
 /**
- * 컬럼 스킴에서 시스템 필드 (group/email/biz) 의 attrs key 추출.
+ * 컬럼 스킴에서 시스템 필드 (분류 기준 = group) 의 attrs key 추출.
  * 휴리스틱: key 가 한국어 표준 명칭이면 그것으로 매핑.
- *
- * 정확한 매핑은 contact_uploads.mapping.systemFields 인덱스 별도 조회 필요하지만
- * 본 슬라이스는 단순 휴리스틱으로 충분 (한국어 헤더 자동 감지와 동일 룰).
+ * 이메일/사업자번호는 contact_pii 사이드 테이블로 이전되어 이 함수에서 더 이상 다루지 않음.
  */
 export function extractSystemFieldKeys(scheme: ContactColumnScheme): SystemFieldKeys {
   const result: SystemFieldKeys = {};
@@ -34,13 +30,6 @@ export function extractSystemFieldKeys(scheme: ContactColumnScheme): SystemField
     const k = attrsKeyOf(c.source);
     if (!k) continue;
     if (!result.group && (k.includes('전시회') || k.includes('캠페인'))) result.group = k;
-    if (
-      !result.email &&
-      (k === '이메일' || k.includes('이메일') || k.toLowerCase().includes('email'))
-    ) {
-      result.email = k;
-    }
-    if (!result.biz && k.includes('사업자')) result.biz = k;
   }
   return result;
 }

--- a/src/lib/operations/contacts.server.ts
+++ b/src/lib/operations/contacts.server.ts
@@ -1,16 +1,21 @@
 import 'server-only';
 import { cache } from 'react';
 
-import { and, asc, desc, eq, ilike, or, sql, type AnyColumn, type SQL } from 'drizzle-orm';
+import { and, asc, desc, eq, ilike, inArray, or, sql, type AnyColumn, type SQL } from 'drizzle-orm';
 
 import { db } from '@/db';
 import { contactTargets, contactUploads, surveys } from '@/db/schema';
 import type { ContactColumnScheme } from '@/db/schema/schema-types';
+import {
+  decryptForTarget,
+  findContactIdsByBlindIndex,
+  findContactIdsByPlainAcrossTypes,
+  getMaskHintsForTargets,
+} from '@/lib/crypto/contact-pii-repo';
+import type { PiiFieldType } from '@/lib/crypto/pii-fields';
 
 import {
   attrsSortKey,
-  maskBizNumber,
-  maskEmail,
   type ContactsSortDir,
   type ContactsSortKey,
   type NormalizedContactListArgs,
@@ -25,10 +30,10 @@ export interface ContactsRow {
   id: string;
   resid: number;
   groupValue: string | null;
-  emailMasked: string;
-  bizMasked: string;
-  /** attrs 통째 (마스킹 안 됨 — UI 에서 컬럼별로 마스킹 적용) */
+  /** attrs 통째 (비PII 만 포함됨 — PII 는 piiMaskHints 에) */
   attrs: Record<string, string>;
+  /** PII 컬럼별 마스킹 힌트 (columnKey → { fieldType, maskHint }) */
+  piiMaskHints: Record<string, { fieldType: PiiFieldType; maskHint: string | null }>;
   /** 최신 attempt result_code (없으면 null) */
   latestResultCode: string | null;
   latestAttemptNo: number | null;
@@ -90,6 +95,11 @@ export async function listContactsForSurvey(
     if (qfield === 'resid') {
       const n = parseInt(trimmed, 10);
       whereParts.push(Number.isFinite(n) && n > 0 ? eq(contactTargets.resid, n) : sql`false`);
+    } else if (qfield === 'email' || qfield === 'biz') {
+      // PII 검색: blind_index 정확 매치. 부분 일치 불가 — UI placeholder 로 안내.
+      const fieldType: PiiFieldType = qfield === 'email' ? 'email' : 'biz_number';
+      const matchedIds = await findContactIdsByBlindIndex(surveyId, fieldType, trimmed);
+      whereParts.push(matchedIds.length > 0 ? inArray(contactTargets.id, matchedIds) : sql`false`);
     } else {
       const escaped = trimmed
         .replace(/\\/g, '\\\\')
@@ -97,20 +107,24 @@ export async function listContactsForSurvey(
         .replace(/_/g, '\\_');
       const pattern = `%${escaped}%`;
 
-      if (qfield === 'email') {
-        whereParts.push(ilike(contactTargets.email, pattern));
-      } else if (qfield === 'biz') {
-        whereParts.push(ilike(contactTargets.bizNumber, pattern));
-      } else if (qfield === 'group') {
+      if (qfield === 'group') {
         whereParts.push(ilike(contactTargets.groupValue, pattern));
       } else {
-        // all
-        const orClause = or(
-          ilike(contactTargets.email, pattern),
-          ilike(contactTargets.bizNumber, pattern),
-          ilike(contactTargets.groupValue, pattern),
+        // all — group_value 부분 일치 + 모든 PII 타입 정확 매치 합집합.
+        // 단일 SQL 로 묶어 round-trip 1회 (이전 구현은 타입별 6번).
+        const piiMatchIds = await findContactIdsByPlainAcrossTypes(
+          surveyId,
+          ['email', 'mobile', 'phone', 'name', 'address', 'biz_number'],
+          trimmed,
         );
-        if (orClause) whereParts.push(orClause);
+        const groupClause = ilike(contactTargets.groupValue, pattern);
+        if (piiMatchIds.length > 0) {
+          const piiClause = inArray(contactTargets.id, piiMatchIds);
+          const combined = or(groupClause, piiClause);
+          if (combined) whereParts.push(combined);
+        } else {
+          whereParts.push(groupClause);
+        }
       }
     }
   }
@@ -132,27 +146,24 @@ export async function listContactsForSurvey(
   const clampedPage = Math.min(Math.max(1, page), totalPages);
   const offset = (clampedPage - 1) * pageSize;
 
-  // 정렬 컬럼 — 시스템 키는 fixed 매핑, attrs.<key> 는 JSONB 추출
+  // 정렬 컬럼 — 시스템 키는 fixed 매핑, attrs.<key> 는 JSONB 추출. PII 정렬 불가.
   const SYSTEM_SORT_MAP = {
     resid: contactTargets.resid,
     respondedAt: contactTargets.respondedAt,
     createdAt: contactTargets.createdAt,
-    email: contactTargets.email,
     group: contactTargets.groupValue,
   } as const;
 
   const attrsKey = attrsSortKey(sort);
   const orderCol: AnyColumn | SQL = attrsKey
     ? sql`${contactTargets.attrs} ->> ${attrsKey}`
-    : SYSTEM_SORT_MAP[sort as keyof typeof SYSTEM_SORT_MAP];
+    : SYSTEM_SORT_MAP[sort as keyof typeof SYSTEM_SORT_MAP] ?? contactTargets.resid;
 
   const dataRows = await db
     .select({
       id: contactTargets.id,
       resid: contactTargets.resid,
       groupValue: contactTargets.groupValue,
-      email: contactTargets.email,
-      bizNumber: contactTargets.bizNumber,
       attrs: contactTargets.attrs,
       respondedAt: contactTargets.respondedAt,
       inviteToken: contactTargets.inviteToken,
@@ -166,13 +177,15 @@ export async function listContactsForSurvey(
     .limit(pageSize)
     .offset(offset);
 
+  // PII 마스킹 힌트 일괄 조회 (cipher 미포함, 비용 낮음)
+  const maskHintsMap = await getMaskHintsForTargets(dataRows.map((r) => r.id));
+
   const rows: ContactsRow[] = dataRows.map((r) => ({
     id: r.id,
     resid: r.resid,
     groupValue: r.groupValue,
-    emailMasked: maskEmail(r.email),
-    bizMasked: maskBizNumber(r.bizNumber),
     attrs: (r.attrs ?? {}) as Record<string, string>,
+    piiMaskHints: maskHintsMap.get(r.id) ?? {},
     latestResultCode: r.latestResultCode,
     latestAttemptNo: r.latestAttemptNo,
     respondedAt: r.respondedAt,
@@ -240,9 +253,13 @@ export interface ContactDetailRow {
   surveyId: string;
   resid: number;
   groupValue: string | null;
-  email: string | null;
-  bizNumber: string | null;
   attrs: Record<string, string>;
+  /**
+   * PII 컬럼 복호화 결과 (columnKey → { fieldType, plain, failed }).
+   * 상세 페이지는 RLS owner check 를 통과한 사용자만 접근하므로 평문 노출 OK.
+   * failed=true 인 항목은 UI 가 readonly 처리해야 함 (cipher 덮어쓰기 방지).
+   */
+  piiDecrypted: Record<string, { fieldType: PiiFieldType; plain: string; failed: boolean }>;
   memo: string | null;
   contactMethod: ContactMethod | null;
   inviteToken: string;
@@ -278,8 +295,6 @@ export async function getContactDetailById(
       surveyId: contactTargets.surveyId,
       resid: contactTargets.resid,
       groupValue: contactTargets.groupValue,
-      email: contactTargets.email,
-      bizNumber: contactTargets.bizNumber,
       attrs: contactTargets.attrs,
       memo: contactTargets.memo,
       contactMethod: contactTargets.contactMethod,
@@ -295,22 +310,26 @@ export async function getContactDetailById(
 
   if (!contact) return null;
 
-  const attempts = await db
-    .select({
-      id: contactAttempts.id,
-      attemptNo: contactAttempts.attemptNo,
-      resultCode: contactAttempts.resultCode,
-      note: contactAttempts.note,
-      createdAt: contactAttempts.createdAt,
-    })
-    .from(contactAttempts)
-    .where(eq(contactAttempts.contactTargetId, id))
-    .orderBy(desc(contactAttempts.attemptNo));
+  const [piiDecrypted, attempts] = await Promise.all([
+    decryptForTarget(id),
+    db
+      .select({
+        id: contactAttempts.id,
+        attemptNo: contactAttempts.attemptNo,
+        resultCode: contactAttempts.resultCode,
+        note: contactAttempts.note,
+        createdAt: contactAttempts.createdAt,
+      })
+      .from(contactAttempts)
+      .where(eq(contactAttempts.contactTargetId, id))
+      .orderBy(desc(contactAttempts.attemptNo)),
+  ]);
 
   return {
     contact: {
       ...contact,
       attrs: (contact.attrs ?? {}) as Record<string, string>,
+      piiDecrypted,
       contactMethod: contact.contactMethod as ContactMethod | null,
     },
     attempts,

--- a/src/lib/operations/contacts.ts
+++ b/src/lib/operations/contacts.ts
@@ -15,7 +15,6 @@ export const CONTACTS_SORT_KEYS = [
   'resid',
   'respondedAt',
   'createdAt',
-  'email',
   'group',
 ] as const;
 export type ContactsSystemSortKey = (typeof CONTACTS_SORT_KEYS)[number];
@@ -155,9 +154,18 @@ export function maskBizNumber(value: string | null | undefined): string {
 
 /**
  * ContactColumnDef.source 에서 attrs key 추출. 'attrs.전시회명' → '전시회명'.
- * system.* 는 null 반환.
+ * system.* / pii.* 는 null 반환.
  */
 export function attrsKeyOf(source: string): string | null {
   if (source.startsWith('attrs.')) return source.slice('attrs.'.length);
+  return null;
+}
+
+/**
+ * ContactColumnDef.source 에서 PII column_key 추출. 'pii.담당자이메일' → '담당자이메일'.
+ * 그 외는 null 반환.
+ */
+export function piiKeyOf(source: string): string | null {
+  if (source.startsWith('pii.')) return source.slice('pii.'.length);
   return null;
 }

--- a/supabase/migrations/0019_lyrical_roland_deschain.sql
+++ b/supabase/migrations/0019_lyrical_roland_deschain.sql
@@ -1,0 +1,92 @@
+-- Migration: 0019_contact_pii
+-- Purpose: PII 사이드 테이블 도입 (contact_pii) + contact_targets 평문 컬럼 제거 + RLS 활성화
+-- Note: 멱등 SQL — 이미 적용된 DB 에 다시 실행해도 안전.
+--       surveys.user_id 가 owner 컬럼 (created_by 아님 — 0019 작성 시점에 정정).
+--
+-- 위험 회피 (이 SQL 작성 시점에 학습된 교훈):
+--   ✗ 절대 금지: TRUNCATE TABLE contact_targets CASCADE
+--     → PG 의 TRUNCATE CASCADE 는 ON DELETE SET NULL 을 무시하고 참조 행 (survey_responses,
+--       response_answers) 까지 모두 강제 TRUNCATE. 응답 데이터 손실 발생.
+--   ✓ 사용: UPDATE NULL + DELETE FROM
+--     → ON DELETE SET NULL FK 액션을 정상 적용하여 survey_responses 행은 보존.
+
+BEGIN;
+
+-- 1) 기존 컨택 데이터 정리 (응답은 보존 — contact_target_id 만 NULL 로 끊음)
+UPDATE "survey_responses" SET "contact_target_id" = NULL
+  WHERE "contact_target_id" IS NOT NULL;
+DELETE FROM "contact_attempts";
+DELETE FROM "contact_targets";
+DELETE FROM "contact_uploads";
+
+-- 2) PII 사이드 테이블 (멱등)
+CREATE TABLE IF NOT EXISTS "contact_pii" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "contact_target_id" uuid NOT NULL REFERENCES "contact_targets"("id") ON DELETE CASCADE,
+  "field_type" text NOT NULL,
+  "column_key" text NOT NULL,
+  "cipher" text NOT NULL,
+  "blind_index" text NOT NULL,
+  "mask_hint" text,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "contact_pii_target_column_unique" UNIQUE ("contact_target_id", "column_key")
+);
+CREATE INDEX IF NOT EXISTS "idx_contact_pii_target" ON "contact_pii" ("contact_target_id");
+CREATE INDEX IF NOT EXISTS "idx_contact_pii_field_blind" ON "contact_pii" ("field_type", "blind_index");
+
+-- 3) contact_targets 평문 PII 컬럼 + 관련 인덱스 제거 (멱등)
+DROP INDEX IF EXISTS "idx_contact_targets_email";
+ALTER TABLE "contact_targets" DROP COLUMN IF EXISTS "email";
+ALTER TABLE "contact_targets" DROP COLUMN IF EXISTS "biz_number";
+
+-- 4) RLS 활성화 + owner-only 정책 (멱등 — 정책 이름으로 DROP IF EXISTS 후 재생성)
+ALTER TABLE "contact_targets" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "contact_pii" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "contact_targets_owner_all" ON "contact_targets";
+CREATE POLICY "contact_targets_owner_all" ON "contact_targets"
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM "surveys" s
+      WHERE s.id = contact_targets.survey_id
+        AND s.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM "surveys" s
+      WHERE s.id = contact_targets.survey_id
+        AND s.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "contact_pii_owner_all" ON "contact_pii";
+CREATE POLICY "contact_pii_owner_all" ON "contact_pii"
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM "contact_targets" ct
+      JOIN "surveys" s ON s.id = ct.survey_id
+      WHERE ct.id = contact_pii.contact_target_id
+        AND s.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM "contact_targets" ct
+      JOIN "surveys" s ON s.id = ct.survey_id
+      WHERE ct.id = contact_pii.contact_target_id
+        AND s.user_id = auth.uid()
+    )
+  );
+
+COMMIT;
+
+-- Rollback (참고용 — 비가역 컬럼 DROP 으로 인해 원상 복귀는 불가능. 백업 복원 필요):
+-- DROP TABLE IF EXISTS "contact_pii";
+-- ALTER TABLE "contact_targets" ADD COLUMN "email" text;
+-- ALTER TABLE "contact_targets" ADD COLUMN "biz_number" text;
+-- CREATE INDEX "idx_contact_targets_email" ON "contact_targets" ("survey_id", "email") WHERE "email" IS NOT NULL;
+-- ALTER TABLE "contact_targets" DISABLE ROW LEVEL SECURITY;
+-- DROP POLICY IF EXISTS "contact_targets_owner_all" ON "contact_targets";

--- a/supabase/migrations/meta/0019_snapshot.json
+++ b/supabase/migrations/meta/0019_snapshot.json
@@ -1,0 +1,1573 @@
+{
+  "id": "10f408b3-9aac-48b4-a129-73010b62b5d6",
+  "prevId": "d1959b9d-a095-4d9d-8b28-13116238cd69",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.question_categories": {
+      "name": "question_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.question_groups": {
+      "name": "question_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "parent_group_id": {
+          "name": "parent_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collapsed": {
+          "name": "collapsed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "display_condition": {
+          "name": "display_condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "question_groups_survey_id_surveys_id_fk": {
+          "name": "question_groups_survey_id_surveys_id_fk",
+          "tableFrom": "question_groups",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.questions": {
+      "name": "questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "options": {
+          "name": "options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "select_levels": {
+          "name": "select_levels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "table_title": {
+          "name": "table_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "table_columns": {
+          "name": "table_columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "table_rows_data": {
+          "name": "table_rows_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "table_header_grid": {
+          "name": "table_header_grid",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_other_option": {
+          "name": "allow_other_option",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "options_columns": {
+          "name": "options_columns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_selections": {
+          "name": "min_selections",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_selections": {
+          "name": "max_selections",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ranking_config": {
+          "name": "ranking_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notice_content": {
+          "name": "notice_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_acknowledgment": {
+          "name": "requires_acknowledgment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "placeholder": {
+          "name": "placeholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_code": {
+          "name": "question_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_custom_spss_var_name": {
+          "name": "is_custom_spss_var_name",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "export_label": {
+          "name": "export_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spss_var_type": {
+          "name": "spss_var_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spss_measure": {
+          "name": "spss_measure",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hide_column_labels": {
+          "name": "hide_column_labels",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "table_validation_rules": {
+          "name": "table_validation_rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dynamic_row_config": {
+          "name": "dynamic_row_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_condition": {
+          "name": "display_condition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "questions_survey_id_surveys_id_fk": {
+          "name": "questions_survey_id_surveys_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "questions_group_id_question_groups_id_fk": {
+          "name": "questions_group_id_question_groups_id_fk",
+          "tableFrom": "questions",
+          "tableTo": "question_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.response_answers": {
+      "name": "response_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text_value": {
+          "name": "text_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "array_value": {
+          "name": "array_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_value": {
+          "name": "object_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question_type": {
+          "name": "question_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "response_answers_response_id_survey_responses_id_fk": {
+          "name": "response_answers_response_id_survey_responses_id_fk",
+          "tableFrom": "response_answers",
+          "tableTo": "survey_responses",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_cells": {
+      "name": "saved_cells",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "cell": {
+          "name": "cell",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cell_type": {
+          "name": "cell_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_questions": {
+      "name": "saved_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "question": {
+          "name": "question",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_preset": {
+          "name": "is_preset",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_responses": {
+      "name": "survey_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_responses": {
+          "name": "question_responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_completed": {
+          "name": "is_completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_progress'"
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_step_id": {
+          "name": "current_step_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_visits": {
+          "name": "page_visits",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "total_seconds": {
+          "name": "total_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_target_id": {
+          "name": "contact_target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_responses_survey_id_surveys_id_fk": {
+          "name": "survey_responses_survey_id_surveys_id_fk",
+          "tableFrom": "survey_responses",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "survey_responses_survey_session_unique": {
+          "name": "survey_responses_survey_session_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_id",
+            "session_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.survey_versions": {
+      "name": "survey_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'published'"
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_note": {
+          "name": "change_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "survey_versions_survey_id_surveys_id_fk": {
+          "name": "survey_versions_survey_id_surveys_id_fk",
+          "tableFrom": "survey_versions",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.surveys": {
+      "name": "surveys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_token": {
+          "name": "private_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "gen_random_uuid()"
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allow_multiple_responses": {
+          "name": "allow_multiple_responses",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "show_progress_bar": {
+          "name": "show_progress_bar",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "shuffle_questions": {
+          "name": "shuffle_questions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "require_login": {
+          "name": "require_login",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_responses": {
+          "name": "max_responses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thank_you_message": {
+          "name": "thank_you_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'응답해주셔서 감사합니다!'"
+        },
+        "contact_columns": {
+          "name": "contact_columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_result_codes": {
+          "name": "contact_result_codes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_columns": {
+          "name": "progress_columns",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "surveys_slug_unique": {
+          "name": "surveys_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_attempts": {
+      "name": "contact_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contact_target_id": {
+          "name": "contact_target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_no": {
+          "name": "attempt_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_code": {
+          "name": "result_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contact_attempts_contact_target_id_contact_targets_id_fk": {
+          "name": "contact_attempts_contact_target_id_contact_targets_id_fk",
+          "tableFrom": "contact_attempts",
+          "tableTo": "contact_targets",
+          "columnsFrom": [
+            "contact_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contact_attempts_target_no_unique": {
+          "name": "contact_attempts_target_no_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contact_target_id",
+            "attempt_no"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_pii": {
+      "name": "contact_pii",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contact_target_id": {
+          "name": "contact_target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "field_type": {
+          "name": "field_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "column_key": {
+          "name": "column_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cipher": {
+          "name": "cipher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blind_index": {
+          "name": "blind_index",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mask_hint": {
+          "name": "mask_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contact_pii_contact_target_id_contact_targets_id_fk": {
+          "name": "contact_pii_contact_target_id_contact_targets_id_fk",
+          "tableFrom": "contact_pii",
+          "tableTo": "contact_targets",
+          "columnsFrom": [
+            "contact_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contact_pii_target_column_unique": {
+          "name": "contact_pii_target_column_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "contact_target_id",
+            "column_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_targets": {
+      "name": "contact_targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resid": {
+          "name": "resid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_value": {
+          "name": "group_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_token": {
+          "name": "invite_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "attrs": {
+          "name": "attrs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "upload_id": {
+          "name": "upload_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_id": {
+          "name": "response_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memo": {
+          "name": "memo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_method": {
+          "name": "contact_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contact_targets_survey_id_surveys_id_fk": {
+          "name": "contact_targets_survey_id_surveys_id_fk",
+          "tableFrom": "contact_targets",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_targets_upload_id_contact_uploads_id_fk": {
+          "name": "contact_targets_upload_id_contact_uploads_id_fk",
+          "tableFrom": "contact_targets",
+          "tableTo": "contact_uploads",
+          "columnsFrom": [
+            "upload_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "contact_targets_response_id_survey_responses_id_fk": {
+          "name": "contact_targets_response_id_survey_responses_id_fk",
+          "tableFrom": "contact_targets",
+          "tableTo": "survey_responses",
+          "columnsFrom": [
+            "response_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contact_targets_survey_resid_unique": {
+          "name": "contact_targets_survey_resid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "survey_id",
+            "resid"
+          ]
+        },
+        "contact_targets_invite_token_unique": {
+          "name": "contact_targets_invite_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invite_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_uploads": {
+      "name": "contact_uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_rows": {
+          "name": "uploaded_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "merged_rows": {
+          "name": "merged_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_rows": {
+          "name": "error_rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "mapping": {
+          "name": "mapping",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contact_uploads_survey_id_surveys_id_fk": {
+          "name": "contact_uploads_survey_id_surveys_id_fk",
+          "tableFrom": "contact_uploads",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail_templates": {
+      "name": "mail_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "survey_id": {
+          "name": "survey_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "body_html": {
+          "name": "body_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "from_local": {
+          "name": "from_local",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "variables_used": {
+          "name": "variables_used",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail_templates_survey_id_surveys_id_fk": {
+          "name": "mail_templates_survey_id_surveys_id_fk",
+          "tableFrom": "mail_templates",
+          "tableTo": "surveys",
+          "columnsFrom": [
+            "survey_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1778226011813,
       "tag": "0018_mail_templates",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1778576941289,
+      "tag": "0019_lyrical_roland_deschain",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,1 +1,4 @@
 import '@testing-library/jest-dom/vitest';
+
+process.env.CONTACT_PII_AES_KEY ??= Buffer.alloc(32, 0xab).toString('base64');
+process.env.CONTACT_PII_HMAC_KEY ??= Buffer.alloc(32, 0xcd).toString('base64');

--- a/tests/unit/domains/contacts/auto-detect.test.ts
+++ b/tests/unit/domains/contacts/auto-detect.test.ts
@@ -1,38 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { autoDetectSystemFields } from '@/lib/contacts/auto-detect';
+import {
+  autoDetectPiiMapping,
+  autoDetectSystemFields,
+  detectPiiType,
+} from '@/lib/contacts/auto-detect';
 
 describe('autoDetectSystemFields', () => {
-  it('정확한 한국어 헤더 매칭', () => {
-    const headers = ['연번', '전시회명(국문)', '기업명', '이메일', '사업자번호', '전화'];
-    expect(autoDetectSystemFields(headers)).toEqual({
-      group: 1,
-      email: 3,
-      biz: 4,
-      phone: 5,
-    });
-  });
-
-  it('"담당자 이메일" 같은 변형도 이메일로 인식', () => {
-    const headers = ['연번', '전시회명', '담당자 이메일'];
-    const r = autoDetectSystemFields(headers);
-    expect(r.email).toBe(2);
-  });
-
-  it('"사업자등록번호" 도 사업자번호로 인식', () => {
-    const headers = ['연번', '기업명', '사업자등록번호'];
-    expect(autoDetectSystemFields(headers).biz).toBe(2);
-  });
-
-  it('헤더에 매칭 없으면 빈 객체', () => {
-    const headers = ['col1', 'col2'];
-    expect(autoDetectSystemFields(headers)).toEqual({});
-  });
-
-  it('휴대폰번호 도 phone 으로 인식', () => {
-    const headers = ['이름', '담당자 휴대폰번호'];
-    expect(autoDetectSystemFields(headers).phone).toBe(1);
-  });
-
   it('group 자동 매칭은 "전시회명" 우선', () => {
     const headers = ['연번', '전시회명', '대륙', '기업명'];
     expect(autoDetectSystemFields(headers).group).toBe(1);
@@ -41,5 +14,57 @@ describe('autoDetectSystemFields', () => {
   it('group 자동 매칭이 없으면 undefined 반환', () => {
     const headers = ['no', 'name', 'email'];
     expect(autoDetectSystemFields(headers).group).toBeUndefined();
+  });
+
+  it('PII (email/biz/phone) 는 더 이상 systemFields 에 속하지 않음 — autoDetectPiiMapping 참고', () => {
+    const headers = ['연번', '전시회명', '이메일', '사업자번호', '전화'];
+    const r = autoDetectSystemFields(headers);
+    expect(r.group).toBe(1);
+    // email/biz/phone 같은 키는 더 이상 존재하지 않음
+    expect(Object.keys(r)).toEqual(['group']);
+  });
+});
+
+describe('detectPiiType', () => {
+  it('정확한 한국어 헤더 → PII 타입 매칭', () => {
+    expect(detectPiiType('이메일')).toBe('email');
+    expect(detectPiiType('사업자번호')).toBe('biz_number');
+    expect(detectPiiType('이름')).toBe('name');
+    expect(detectPiiType('주소')).toBe('address');
+  });
+
+  it('휴대폰 패턴은 phone 보다 먼저 mobile 로 매칭', () => {
+    expect(detectPiiType('휴대폰')).toBe('mobile');
+    expect(detectPiiType('휴대폰번호')).toBe('mobile');
+    expect(detectPiiType('전화')).toBe('phone');
+    expect(detectPiiType('전화번호')).toBe('phone');
+  });
+
+  it('변형 표현도 부분 포함으로 매칭', () => {
+    expect(detectPiiType('담당자 이메일')).toBe('email');
+    expect(detectPiiType('사업자등록번호')).toBe('biz_number');
+    expect(detectPiiType('담당자 휴대폰번호')).toBe('mobile');
+  });
+
+  it('PII 키워드 없으면 undefined', () => {
+    expect(detectPiiType('연번')).toBeUndefined();
+    expect(detectPiiType('전시회명')).toBeUndefined();
+    expect(detectPiiType('')).toBeUndefined();
+  });
+});
+
+describe('autoDetectPiiMapping', () => {
+  it('여러 PII 컬럼을 헤더 → 타입 매핑으로 반환', () => {
+    const headers = ['연번', '전시회명', '담당자 이메일', '사업자번호', '담당자 휴대폰번호'];
+    const mapping = autoDetectPiiMapping(headers);
+    expect(mapping).toEqual({
+      '담당자 이메일': 'email',
+      '사업자번호': 'biz_number',
+      '담당자 휴대폰번호': 'mobile',
+    });
+  });
+
+  it('PII 키워드 없으면 빈 객체', () => {
+    expect(autoDetectPiiMapping(['연번', '전시회명', '기업명'])).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary

엑셀 컨택 명단의 PII를 `contact_pii` 사이드 테이블에 AES-256-GCM 암호화 저장. 검색을 위한 HMAC blind index, 마스킹 힌트 사전 계산, RLS 정책까지 포함된 풀스택 작업.

## 핵심 변경

- **스키마**: `contact_pii` 사이드 테이블 신규(`cipher`/`blind_index`/`mask_hint`). `contact_targets.email`/`biz_number` 컬럼 제거. RLS 활성화 + owner-only 정책. `invite_token` lookup용 SECURITY DEFINER 함수.
- **암호화**: AES-256-GCM 버전 dispatch(v1 → v2 dual-decrypt 준비), HMAC-SHA256 blind index, 정규화 후 mask hint 사전 저장. 부팅 시 키 fail-fast 검증.
- **업로드 마법사**: 매핑 단계를 행 기반 매트릭스로 재구성. 컬럼별 라벨/PII 타입/표시/분류 기준 한 줄. 한국어 헤더 자동 prefill.
- **상세 페이지**: PII 컬럼 평문 인라인 편집 → 저장 시 자동 재암호화. 복호화 실패 시 readonly + 덮어쓰기 방지.
- **컨택 목록**: PII 검색(`qfield='email'`/`'biz'`) blind index 정확 매치, 'all' 통합검색 단일 SQL로 PII 6타입 동시 매치.
- **편집 보호**: 액션 진입점 `attrs` sanitize로 UI 우회 시 PII가 attrs 평문 누적되는 것 차단. PII 비우면 confirm dialog.

## 머지 후 영향 (메일 브랜치 측 대응 필요)

`feat/mail-unsubscribe-attachments` 브랜치가 `contact_targets.email`/`bizNumber` 컬럼을 직접 참조하는 6개 파일은 머지 후 깨집니다:
- src/actions/campaign-actions.ts
- src/actions/unsubscribe-actions.ts
- src/lib/mail/campaign-dispatch.ts
- src/lib/operations/campaigns.server.ts
- src/lib/operations/contact-sample.server.ts
- src/lib/operations/contacts.server.ts

수정 패턴: \`decryptForTarget()\` / \`findContactIdsByBlindIndex()\` 헬퍼 활용.

## Test plan

- [x] TypeScript 타입체크 통과
- [x] 단위 테스트 412/412 통과
- [x] 클린 빌드 성공
- [x] 마이그레이션 0019 dev DB 적용 (TRUNCATE CASCADE → UPDATE NULL + DELETE FROM 패턴으로 안전화)
- [x] 엑셀 명단 업로드 → contact_pii 분리 저장 동작 확인 (475건)
- [x] 컨택 상세 페이지 PII 평문 편집 동작
- [x] 마스킹 힌트 새 규칙으로 일괄 갱신 (1883건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)