### PR TITLE
feat: radio 옵션 그룹 - 빌더 지정 UI + 그룹별 응답 + SPSS 그룹 변수 export

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -13,8 +13,8 @@ project_name: "survey-table-project"
 #   perl                php                 php_phpactor        powershell          python
 #   python_jedi         python_ty           r                   rego                ruby
 #   ruby_solargraph     rust                scala               scss                solidity
-#   swift               systemverilog       terraform           toml                typescript
-#   typescript_vts      vue                 yaml                zig
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
@@ -22,6 +22,7 @@ project_name: "survey-table-project"
 #   - For C, use cpp
 #   - For JavaScript, use typescript
 #   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
 #   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
@@ -32,6 +33,7 @@ project_name: "survey-table-project"
 # Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
 languages:
 - typescript
+- python
 
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -567,7 +567,7 @@ export function QuestionEditor({ questionId, onSave }: Props) {
 
 - **코드 SoT**: 디자인 토큰의 실제 source of truth는 [globals.css](src/app/globals.css)의 `:root` CSS 변수 + `@theme inline` 매핑. DESIGN.md는 목표 명세, globals.css가 현재 구현.
 - **적용 범위 주의**: DESIGN.md 명세는 Apple 마케팅/쇼케이스 사이트 기준(17px body, 80px 섹션, 저밀도 tile). **설문 빌더·운영 콘솔은 고밀도 도구 UI**라 토큰(색·radius·그림자 절제·weight ladder)만 참조하고 마케팅 스케일/밀도는 적용하지 않는다. Apple 정통 스케일은 랜딩·공개 응답 페이지(`/survey`)에 적합.
-- **현재 코드 갭(미정렬)**: primary 토큰 `#007aff`(명세 `#0066cc`), 버튼이 토큰 대신 `bg-blue-500` 직접 사용, 버튼 radius `rounded-lg`(명세 pill), `shadow-sm` 등 사용(명세 금지), `font-medium`(500, 명세 제외). 코드 정렬은 별도 작업.
+- **색상 명세 정렬(2026-06-11)**: DESIGN.md 블루 계열을 코드 버튼 관행으로 갱신 — primary `#3b82f6`(blue-500), hover `#2563eb`(blue-600), on-dark `#60a5fa`(blue-400). 잔여 갭: globals.css `--primary`(#007aff) 토큰 불일치, 버튼 radius `rounded-lg`(명세 pill), `shadow-sm` 사용(명세 금지), `font-medium`(500, 명세 제외) — 코드 정렬은 별도 작업.
 
 ---
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -9,7 +9,8 @@
 - **적용 범위 주의 (중요)**: 이 명세는 Apple의 **마케팅/제품 쇼케이스 사이트** 기준이다 (hero 56px, body 17px, 섹션 패딩 80px, "1 viewport = 1 tile" 저밀도 레이아웃). 반면 이 프로젝트의 본체인 **설문 빌더·운영 콘솔은 데이터 밀도가 높은 도구(tool) UI**다.
   - 도구 UI에는 **토큰(색·ink·parchment·radius 스케일·그림자 절제·weight ladder)만 참조**하고, 17px body·80px 섹션·저밀도 tile 레이아웃은 그대로 적용하지 않는다.
   - Apple 정통 스케일이 어울리는 곳은 **랜딩 페이지·공개 설문 응답 페이지(`/survey`)** 쪽이다.
-- **현재 코드와의 갭 (아직 미반영)**: 이 문서는 목표 명세이고 코드는 아직 정렬되지 않았다. 알려진 갭 — primary 토큰 `#007aff`(명세는 `#0066cc`), 버튼이 토큰 대신 `bg-blue-500`(#3b82f6) 직접 사용, 버튼 radius `rounded-lg`(8px, 명세는 pill), `shadow-sm` 등 카드/버튼 그림자 사용(명세는 금지), `font-medium`(weight 500, 명세는 500 제외). 코드 정렬은 별도 작업으로 진행한다.
+- **색상 명세는 코드 관행 기준 (2026-06-11 정렬)**: 블루 계열은 실제 버튼 관행을 SoT로 채택했다 — primary `#3b82f6`(Tailwind blue-500, `bg-blue-500`), hover/press `#2563eb`(blue-600), on-dark 링크 `#60a5fa`(blue-400). 원본 Apple 명세(#0066cc 계열)는 폐기. 단 [globals.css](src/app/globals.css)의 `--primary` 토큰은 아직 `#007aff`로 버튼과 불일치 — 추후 `#3b82f6`로 정렬하거나 버튼이 토큰을 쓰도록 전환(별도 작업).
+- **잔여 코드 갭 (색상 외)**: 버튼 radius `rounded-lg`(8px, 명세는 pill), `shadow-sm` 등 카드/버튼 그림자 사용(명세는 금지), `font-medium`(weight 500, 명세는 500 제외). 코드 정렬은 별도 작업으로 진행한다.
 
 ---
 
@@ -24,7 +25,7 @@ Store and shop surfaces retain the same chassis but switch modes. The product co
 **Key Characteristics:**
 - Photography-first presentation; UI recedes so the product can speak.
 - Alternating full-bleed tile sections: white/parchment ↔ near-black, with the color change itself acting as the section divider.
-- Single blue accent (`{colors.primary}` — #0066cc) carries every interactive element. No second brand color exists.
+- Single blue accent (`{colors.primary}` — #3b82f6) carries every interactive element. No second brand color exists.
 - Two button grammars: tiny blue pill CTAs (`{rounded.pill}`) and compact utility rects (`{rounded.sm}`).
 - Wanted Sans Variable (substituted for SF Pro Display/Text) — negative letter-spacing at display sizes for the signature "Apple tight" headline feel.
 - Whisper-soft elevation used only when a product image needs to breathe — exactly one drop-shadow in the entire system.
@@ -36,9 +37,9 @@ Store and shop surfaces retain the same chassis but switch modes. The product co
 > **Source pages analyzed:** homepage, environment, store, iPhone 17 Pro buy page, accessories index. The color system is identical across all five surfaces; only the surface-mode mix differs.
 
 ### Brand & Accent
-- **Action Blue** (`{colors.primary}` — #0066cc): The single brand-level interactive color. All text links, all blue pill CTAs ("Learn more", "Buy"), and the focus ring root. This is Apple's quiet but universal "click me" signal. Press state shifts to a slightly darker variant via the active scale transform rather than a hex change.
-- **Focus Blue** (`{colors.primary-focus}` — #0071e3): A marginally brighter sibling of Action Blue, reserved for the keyboard focus ring on buttons (`outline: 2px solid`).
-- **Sky Link Blue** (`{colors.primary-on-dark}` — #2997ff): A brighter blue used on dark surfaces for in-copy links and inline callouts, where Action Blue would disappear against the tile background.
+- **Action Blue** (`{colors.primary}` — #3b82f6): The single brand-level interactive color. All text links, all blue pill CTAs ("Learn more", "Buy"), and the focus ring root. This is the project's universal "click me" signal (Tailwind blue-500 — 코드 버튼 관행 `bg-blue-500`). Hover/press darkens one step to `{colors.primary-focus}` (#2563eb, blue-600) — `hover:bg-blue-600`.
+- **Hover/Press Blue** (`{colors.primary-focus}` — #2563eb): One step darker than Action Blue (Tailwind blue-600). Used for hover/pressed states and selected borders. Keyboard focus ring uses Action Blue itself (`focus-visible:ring-1 ring-blue-500` — 코드 관행).
+- **Sky Link Blue** (`{colors.primary-on-dark}` — #60a5fa): A brighter blue (Tailwind blue-400) used on dark surfaces for in-copy links and inline callouts, where Action Blue would disappear against the tile background.
 
 ### Surface
 - **Pure White** (`{colors.canvas}` — #ffffff): The dominant canvas. Content, utility cards, store tiles, configurator grids.
@@ -178,7 +179,7 @@ Apple's whitespace is the product's pedestal. Every tile begins with at least 64
 
 ### Buttons
 
-**`button-primary`** — The signature Apple action. Background `{colors.primary}` (Action Blue #0066cc), text `{colors.on-primary}` in `{typography.body}` (Wanted Sans 17px / 400), rounded `{rounded.pill}` (full pill — capsule-shaped), padding 11px × 22px. The full-pill radius IS the brand action signal.
+**`button-primary`** — The signature Apple action. Background `{colors.primary}` (Action Blue #3b82f6), text `{colors.on-primary}` in `{typography.body}` (Wanted Sans 17px / 400), rounded `{rounded.pill}` (full pill — capsule-shaped), padding 11px × 22px. The full-pill radius IS the brand action signal.
 - Active state: `{component.button-primary-active}` — `transform: scale(0.95)` (the system-wide micro-interaction).
 - Focus state: `{component.button-primary-focus}` — 2px solid `{colors.primary-focus}` outline.
 
@@ -194,7 +195,7 @@ Apple's whitespace is the product's pedestal. Every tile begins with at least 64
 
 **`text-link`** — Inline body links in `{colors.primary}` (Action Blue). Underlined or non-underlined per context.
 
-**`text-link-on-dark`** — Inline body links on dark tiles in `{colors.primary-on-dark}` (Sky Link Blue #2997ff) — Action Blue would disappear against `{colors.surface-tile-1}`.
+**`text-link-on-dark`** — Inline body links on dark tiles in `{colors.primary-on-dark}` (Sky Link Blue #60a5fa) — Action Blue would disappear against `{colors.surface-tile-1}`.
 
 ### Cards & Containers
 
@@ -231,7 +232,7 @@ Error and validation states were not surfaced in the analyzed pages.
 ## Do's and Don'ts
 
 ### Do
-- Use `{colors.primary}` (Action Blue #0066cc) for every interactive element — links, pill CTAs, focus signals — and nothing else. The single accent is non-negotiable.
+- Use `{colors.primary}` (Action Blue #3b82f6) for every interactive element — links, pill CTAs, focus signals — and nothing else. The single accent is non-negotiable.
 - Set headlines in `{typography.hero-display}` or `{typography.display-lg}` with negative letter-spacing (eased for Wanted Sans per the substitution note) to get the signature "Apple tight" cadence.
 - Run body copy at `{typography.body}` (17px / 400 / 1.47 / tracking eased for Wanted Sans) on marketing/landing surfaces — not 16px. (도구 UI는 더 높은 밀도를 쓴다.)
 - Alternate `{component.product-tile-light}` (or parchment) and `{component.product-tile-dark}` for full-bleed section rhythm. The color change IS the divider.

--- a/src/components/survey-builder/cell-content-modal.tsx
+++ b/src/components/survey-builder/cell-content-modal.tsx
@@ -325,15 +325,18 @@ export function CellContentModal({
 
           // choice_opt 저장 시 choiceGroups 도 함께 저장한다.
           // prune 은 updatedRowsData 기준으로 계산해 빈 그룹이 DB 에 남지 않도록 한다.
+          // 마지막 멤버 해제로 전부 비면 빈 배열을 명시 저장해야 phantom 그룹이 남지 않는다.
           const prunedChoiceGroups = (() => {
-            if (contentType !== 'choice_opt' || editChoiceGroups.length === 0) return undefined;
+            if (contentType !== 'choice_opt') return undefined;
             const memberIds = new Set(
               collectChoiceOptCells(updatedRowsData)
                 .map((c) => c.choiceGroupId)
                 .filter((id): id is string => !!id),
             );
             const pruned = editChoiceGroups.filter((g) => memberIds.has(g.id));
-            return pruned.length > 0 ? pruned : undefined;
+            // 원래도 그룹이 없던 질문이면 빈 배열을 굳이 쓰지 않는다 (NULL 유지)
+            if (pruned.length === 0 && (question.choiceGroups ?? []).length === 0) return undefined;
+            return pruned;
           })();
 
           try {

--- a/src/components/survey-builder/cell-content-modal.tsx
+++ b/src/components/survey-builder/cell-content-modal.tsx
@@ -302,16 +302,17 @@ export function CellContentModal({
       // 폼 상태를 저장될 TableCell 로 직렬화 (조건부 spread 로 optional 필드 처리).
       const updatedCell: TableCell = buildUpdatedCell(form, cell);
 
+      // 로컬 스토어 업데이트 (셀 저장) — onChoiceGroupsChange 보다 먼저 수행해야
+      // dynamic-table-editor 의 currentRowsRef 가 이미 새 셀을 포함한 상태에서 prune 이 동작한다.
+      onSave(updatedCell);
+
       // choice_opt 탭에서 그룹 변경이 있었으면 정리 후 부모에게 통보.
-      // prune 은 updatedCell(이 셀 반영 후)의 rowsData 기준으로 계산해야 하지만,
-      // prune 함수가 question 전체를 인자로 받으므로 여기서는 editChoiceGroups 를 직접 전달한다.
+      // prune 은 updatedCell(이 셀 반영 후)의 rowsData 기준으로 계산해야 하므로
+      // onSave(셀 반영) 다음에 호출한다.
       // 실질적인 prune(빈 그룹 제거)은 dynamic-table-editor 의 onChoiceGroupsChange 핸들러에서 수행한다.
       if (contentType === 'choice_opt') {
         onChoiceGroupsChange?.(editChoiceGroups);
       }
-
-      // 로컬 스토어 업데이트 (셀 저장)
-      onSave(updatedCell);
 
       // 서버에 질문 저장/업데이트
       if (currentQuestionId && useSurveyBuilderStore.getState().currentSurvey.id) {
@@ -390,6 +391,7 @@ export function CellContentModal({
                 ...(question.requiresAcknowledgment !== undefined ? { requiresAcknowledgment: question.requiresAcknowledgment } : {}),
                 ...(question.tableValidationRules !== undefined ? { tableValidationRules: question.tableValidationRules } : {}),
                 ...(question.displayCondition !== undefined ? { displayCondition: question.displayCondition } : {}),
+                ...(prunedChoiceGroups !== undefined ? { choiceGroups: prunedChoiceGroups } : {}),
               });
 
               // 반환된 UUID로 로컬 스토어의 질문 ID 업데이트 + Case 2 참조 동기화

--- a/src/components/survey-builder/cell-content-modal.tsx
+++ b/src/components/survey-builder/cell-content-modal.tsx
@@ -47,7 +47,8 @@ import { isValidUUID } from '@/lib/utils';
 import { generateId } from '@/lib/utils';
 import { useSurveyBuilderStore } from '@/stores/survey-store';
 import { useSurveyUIStore } from '@/stores/ui-store';
-import { TableCell } from '@/types/survey';
+import { ChoiceGroup, TableCell } from '@/types/survey';
+import { collectChoiceOptCells } from '@/utils/choice-source';
 import { isPartialNumericInput } from '@/utils/numeric-input';
 import { getMaxSpssCode } from '@/utils/option-code-generator';
 import { hasExistingOtherRankingCell } from '@/utils/ranking-source';
@@ -99,6 +100,10 @@ interface CellContentModalProps {
   rowLabel?: string | undefined;
   columnCode?: string | undefined;
   columnLabel?: string | undefined;
+  /** choice_opt 탭용: 질문 레벨 옵션 그룹 목록 (표시/편집용). 없으면 그룹 기능 비활성. */
+  choiceGroups?: ChoiceGroup[] | undefined;
+  /** choice_opt 그룹 변경 시 부모에게 통보 (prune 후 저장은 부모 책임) */
+  onChoiceGroupsChange?: ((groups: ChoiceGroup[]) => void) | undefined;
 }
 
 export function CellContentModal({
@@ -112,6 +117,8 @@ export function CellContentModal({
   rowLabel,
   columnCode,
   columnLabel,
+  choiceGroups: choiceGroupsProp,
+  onChoiceGroupsChange,
 }: CellContentModalProps) {
   const questions = useSurveyBuilderStore(useShallow((s) => s.currentSurvey.questions));
   const variableCatalog = useSurveyUIStore((s) => s.variableCatalog);
@@ -153,6 +160,7 @@ export function CellContentModal({
     choiceLabel,
     choiceAllowTextInput,
     choiceBranchRule,
+    choiceGroupId,
     horizontalAlign,
     mobileDisplay,
     verticalAlign,
@@ -196,6 +204,7 @@ export function CellContentModal({
     setChoiceLabel,
     setChoiceAllowTextInput,
     setChoiceBranchRule,
+    setChoiceGroupId,
     setHorizontalAlign,
     setMobileDisplay,
     setVerticalAlign,
@@ -210,6 +219,37 @@ export function CellContentModal({
     setSpssVarType,
     setSpssMeasure,
   } = setters;
+
+  // choice_opt 탭용 로컬 그룹 편집 상태.
+  // 부모에서 choiceGroupsProp 를 전달받으면 그 값으로, 아니면 스토어 질문의 choiceGroups 를 사용한다.
+  // 모달이 열릴 때(isOpen + cell.id 변경) 재동기화하기 위해 useState 초기값은 lazy initializer 로 설정하지 않고
+  // useEffect 로 동기화한다. (isOpen 이 꺼지면 닫는 시점이므로 재설정이 무해하다.)
+  const [editChoiceGroups, setEditChoiceGroups] = useState<ChoiceGroup[]>(
+    () => choiceGroupsProp ?? [],
+  );
+  useEffect(() => {
+    if (isOpen) {
+      const storeQuestion = useSurveyBuilderStore
+        .getState()
+        .currentSurvey.questions.find((q) => q.id === currentQuestionId);
+      setEditChoiceGroups(choiceGroupsProp ?? storeQuestion?.choiceGroups ?? []);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, cell?.id]);
+
+  // 현재 질문 tableRowsData 기반으로 그룹별 멤버 셀 수를 계산한다 (표시용).
+  // 아직 저장되지 않은 이번 편집 셀은 카운트에 반영되지 않아도 무방하다.
+  const groupMemberCounts = (() => {
+    const storeQuestion = questions.find((q) => q.id === currentQuestionId);
+    const allCells = collectChoiceOptCells(storeQuestion?.tableRowsData);
+    const counts: Record<string, number> = {};
+    for (const c of allCells) {
+      if (c.choiceGroupId) {
+        counts[c.choiceGroupId] = (counts[c.choiceGroupId] ?? 0) + 1;
+      }
+    }
+    return counts;
+  })();
 
   // 자동생성 셀코드/라벨 계산
   const autoCellCode = generateCellCode(questionCode, rowCode, columnCode);
@@ -262,6 +302,14 @@ export function CellContentModal({
       // 폼 상태를 저장될 TableCell 로 직렬화 (조건부 spread 로 optional 필드 처리).
       const updatedCell: TableCell = buildUpdatedCell(form, cell);
 
+      // choice_opt 탭에서 그룹 변경이 있었으면 정리 후 부모에게 통보.
+      // prune 은 updatedCell(이 셀 반영 후)의 rowsData 기준으로 계산해야 하지만,
+      // prune 함수가 question 전체를 인자로 받으므로 여기서는 editChoiceGroups 를 직접 전달한다.
+      // 실질적인 prune(빈 그룹 제거)은 dynamic-table-editor 의 onChoiceGroupsChange 핸들러에서 수행한다.
+      if (contentType === 'choice_opt') {
+        onChoiceGroupsChange?.(editChoiceGroups);
+      }
+
       // 로컬 스토어 업데이트 (셀 저장)
       onSave(updatedCell);
 
@@ -275,6 +323,19 @@ export function CellContentModal({
             cells: row.cells.map((c) => (c.id === cell.id ? updatedCell : c)),
           }));
 
+          // choice_opt 저장 시 choiceGroups 도 함께 저장한다.
+          // prune 은 updatedRowsData 기준으로 계산해 빈 그룹이 DB 에 남지 않도록 한다.
+          const prunedChoiceGroups = (() => {
+            if (contentType !== 'choice_opt' || editChoiceGroups.length === 0) return undefined;
+            const memberIds = new Set(
+              collectChoiceOptCells(updatedRowsData)
+                .map((c) => c.choiceGroupId)
+                .filter((id): id is string => !!id),
+            );
+            const pruned = editChoiceGroups.filter((g) => memberIds.has(g.id));
+            return pruned.length > 0 ? pruned : undefined;
+          })();
+
           try {
             await ensureSurvey();
 
@@ -282,7 +343,10 @@ export function CellContentModal({
               // 이미 DB에 저장된 질문: 업데이트
               await client.surveyBuilder.questions.update({
                 questionId: currentQuestionId,
-                data: { tableRowsData: updatedRowsData },
+                data: {
+                  tableRowsData: updatedRowsData,
+                  ...(prunedChoiceGroups !== undefined ? { choiceGroups: prunedChoiceGroups } : {}),
+                },
               });
               // store 도 동일 데이터로 동기화. 표시 조건/장기 계산식 picker 가
               // store 를 직접 구독하므로 누락 시 셀 라벨 변경이 stale 로 표시됨.
@@ -290,7 +354,13 @@ export function CellContentModal({
                 currentSurvey: {
                   ...state.currentSurvey,
                   questions: state.currentSurvey.questions.map((q) =>
-                    q.id === currentQuestionId ? { ...q, tableRowsData: updatedRowsData } : q,
+                    q.id === currentQuestionId
+                      ? {
+                          ...q,
+                          tableRowsData: updatedRowsData,
+                          ...(prunedChoiceGroups !== undefined ? { choiceGroups: prunedChoiceGroups } : {}),
+                        }
+                      : q,
                   ),
                 },
               }));
@@ -986,6 +1056,11 @@ export function CellContentModal({
               onBranchRuleChange={setChoiceBranchRule}
               allQuestions={questions}
               currentQuestionId={currentQuestionId}
+              choiceGroups={editChoiceGroups}
+              groupMemberCounts={groupMemberCounts}
+              choiceGroupId={choiceGroupId}
+              onChoiceGroupIdChange={setChoiceGroupId}
+              onChoiceGroupsChange={setEditChoiceGroups}
             />
           </TabsContent>
         </Tabs>

--- a/src/components/survey-builder/choice-opt-cell-tab.tsx
+++ b/src/components/survey-builder/choice-opt-cell-tab.tsx
@@ -89,6 +89,7 @@ export function ChoiceOptCellTab({
         <div className="flex gap-1">
           <button
             type="button"
+            aria-pressed="true"
             className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white"
           >
             라디오

--- a/src/components/survey-builder/choice-opt-cell-tab.tsx
+++ b/src/components/survey-builder/choice-opt-cell-tab.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { Tag } from 'lucide-react';
-
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
-import { BranchRule, Question } from '@/types/survey';
+import { BranchRule, ChoiceGroup, Question } from '@/types/survey';
+import { generateId } from '@/lib/utils';
+import { nextGroupKey } from '@/utils/choice-group-helpers';
 
 import { BranchRuleEditor } from './branch-rule-editor';
 
@@ -23,6 +23,14 @@ interface ChoiceOptCellTabProps {
   allQuestions: Question[];
   /** 현재 질문 ID (분기 대상은 이 질문 이후만 노출) */
   currentQuestionId: string;
+  /** 질문 레벨의 radio 그룹 목록 */
+  choiceGroups: ChoiceGroup[];
+  /** 그룹 id → 멤버 셀 수 (표시용) */
+  groupMemberCounts: Record<string, number>;
+  /** 현재 셀이 속한 그룹 id. 빈 문자열 = 미소속 */
+  choiceGroupId: string;
+  onChoiceGroupIdChange: (id: string) => void;
+  onChoiceGroupsChange: (groups: ChoiceGroup[]) => void;
 }
 
 /**
@@ -40,20 +48,106 @@ export function ChoiceOptCellTab({
   onBranchRuleChange,
   allQuestions,
   currentQuestionId,
+  choiceGroups,
+  groupMemberCounts,
+  choiceGroupId,
+  onChoiceGroupIdChange,
+  onChoiceGroupsChange,
 }: ChoiceOptCellTabProps) {
+  const radioGroups = choiceGroups.filter((g) => g.type === 'radio');
+  const nextKey = nextGroupKey(radioGroups, 'radio');
+  const currentGroup = radioGroups.find((g) => g.id === choiceGroupId);
+
+  function handleGroupSelectChange(value: string) {
+    if (value === '__new__') {
+      const key = nextGroupKey(choiceGroups, 'radio');
+      const newGroup: ChoiceGroup = {
+        id: generateId(),
+        groupKey: key,
+        type: 'radio',
+        label: '',
+      };
+      onChoiceGroupsChange([...choiceGroups, newGroup]);
+      onChoiceGroupIdChange(newGroup.id);
+    } else {
+      onChoiceGroupIdChange(value);
+    }
+  }
+
+  function handleGroupLabelChange(label: string) {
+    if (!currentGroup) return;
+    onChoiceGroupsChange(
+      choiceGroups.map((g) => (g.id === choiceGroupId ? { ...g, label } : g)),
+    );
+  }
+
   return (
     <div className="space-y-4">
-      <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-3">
-        <div className="flex items-start gap-2">
-          <Tag className="mt-0.5 h-5 w-5 flex-shrink-0 text-emerald-600" />
-          <div>
-            <p className="text-sm font-medium text-emerald-900">보기 옵션 소스 (Case A)</p>
-            <p className="mt-1 text-xs text-emerald-700">
-              이 셀은 질문(단일/복수 선택)의 보기로 사용됩니다. 응답자는 이 셀에서 선택하며,
-              응답은 일반 radio/checkbox 와 동일하게 저장됩니다.
-            </p>
-          </div>
+      {/* 옵션 종류 세그먼트 — 라디오만 활성 */}
+      <div className="space-y-1.5">
+        <Label className="text-sm font-medium">옵션 종류</Label>
+        <div className="flex gap-1">
+          <button
+            type="button"
+            className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white"
+          >
+            라디오
+          </button>
+          <button
+            type="button"
+            disabled
+            title="추후 지원"
+            className="cursor-not-allowed rounded-md bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-400"
+          >
+            체크박스
+          </button>
+          <button
+            type="button"
+            disabled
+            title="추후 지원"
+            className="cursor-not-allowed rounded-md bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-400"
+          >
+            순위
+          </button>
         </div>
+      </div>
+
+      {/* 그룹 select + 그룹 라벨 한 줄 */}
+      <div className="space-y-1.5">
+        <Label htmlFor="choice-opt-group-select" className="text-sm font-medium">
+          그룹
+        </Label>
+        <div className="flex gap-2">
+          <select
+            id="choice-opt-group-select"
+            aria-label="그룹"
+            value={choiceGroupId}
+            onChange={(e) => handleGroupSelectChange(e.target.value)}
+            className="flex-1 rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="">(그룹 없음)</option>
+            {radioGroups.map((g) => (
+              <option key={g.id} value={g.id}>
+                {g.groupKey}
+                {g.label ? ` — ${g.label}` : ''}
+                {' · 셀 '}
+                {groupMemberCounts[g.id] ?? 0}
+              </option>
+            ))}
+            <option value="__new__">+ 새 그룹 ({nextKey})</option>
+          </select>
+          <Input
+            aria-label="그룹 라벨"
+            placeholder="그룹 라벨 (그룹을 선택하세요)"
+            value={currentGroup?.label ?? ''}
+            disabled={!currentGroup}
+            onChange={(e) => handleGroupLabelChange(e.target.value)}
+            className="flex-1"
+          />
+        </div>
+        <p className="text-xs text-gray-500">
+          같은 그룹의 셀들 중 하나만 선택됩니다. 그룹 라벨 수정은 그룹 전체에 반영됩니다.
+        </p>
       </div>
 
       <div className="flex items-center justify-between gap-4">
@@ -61,44 +155,42 @@ export function ChoiceOptCellTab({
         <Switch checked={allowTextInput} onCheckedChange={onAllowTextInputChange} />
       </div>
 
-      <div className="space-y-2">
-        <Label htmlFor="choice-opt-label" className="text-sm font-medium">
-          옵션 라벨
-        </Label>
-        <Input
-          id="choice-opt-label"
-          value={choiceLabel}
-          onChange={(e) => onChoiceLabelChange(e.target.value)}
-          placeholder="옵션 라벨 (비워두면 셀 본문 텍스트가 사용됨)"
-        />
-        <p className="text-xs text-gray-500">
-          선택 열 셀은 보통 비어 있으므로(라벨이 다른 열에 있음) 분석/SPSS 라벨을 여기에 명시하세요.
-        </p>
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="choice-opt-spss-code" className="text-sm font-medium">
-          응답값 (선택)
-        </Label>
-        <Input
-          id="choice-opt-spss-code"
-          type="number"
-          inputMode="numeric"
-          value={spssNumericCode}
-          onChange={(e) => {
-            const v = e.target.value;
-            if (v === '') onSpssNumericCodeChange('');
-            else {
-              const n = parseInt(v, 10);
-              if (!Number.isNaN(n)) onSpssNumericCodeChange(n);
-            }
-          }}
-          placeholder="(비워두면 자동: 수집 순서 기반 1-based 인덱스)"
-          className="w-64"
-        />
-        <p className="text-xs text-gray-500">
-          SPSS 변수의 값으로 기록됩니다. 셀 순서가 바뀌어도 값이 유지되길 원하면 명시하세요.
-        </p>
+      {/* 옵션 라벨 + 응답값 한 줄 배치 */}
+      <div className="space-y-1.5">
+        <Label className="text-sm font-medium">옵션 라벨 / 응답값</Label>
+        <div className="flex items-start gap-2">
+          <div className="flex-1 space-y-1">
+            <Input
+              id="choice-opt-label"
+              value={choiceLabel}
+              onChange={(e) => onChoiceLabelChange(e.target.value)}
+              placeholder="옵션 라벨 (비워두면 셀 본문 텍스트 사용)"
+            />
+            <p className="text-xs text-gray-500">
+              선택 열 셀은 보통 비어 있으므로(라벨이 다른 열에 있음) 분석/SPSS 라벨을 여기에 명시하세요.
+            </p>
+          </div>
+          <div className="w-44 space-y-1">
+            <Input
+              id="choice-opt-spss-code"
+              type="number"
+              inputMode="numeric"
+              value={spssNumericCode}
+              onChange={(e) => {
+                const v = e.target.value;
+                if (v === '') onSpssNumericCodeChange('');
+                else {
+                  const n = parseInt(v, 10);
+                  if (!Number.isNaN(n)) onSpssNumericCodeChange(n);
+                }
+              }}
+              placeholder="응답값 (선택)"
+            />
+            <p className="text-xs text-gray-500">
+              SPSS 값으로 기록됩니다. 셀 순서가 바뀌어도 유지되길 원하면 명시하세요.
+            </p>
+          </div>
+        </div>
       </div>
 
       <BranchRuleEditor

--- a/src/components/survey-builder/choice-opt-cell-tab.tsx
+++ b/src/components/survey-builder/choice-opt-cell-tab.tsx
@@ -90,7 +90,7 @@ export function ChoiceOptCellTab({
           <button
             type="button"
             aria-pressed="true"
-            className="rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white"
+            className="rounded-md bg-blue-500 px-3 py-1.5 text-xs font-medium text-white"
           >
             라디오
           </button>

--- a/src/components/survey-builder/dynamic-table-editor.tsx
+++ b/src/components/survey-builder/dynamic-table-editor.tsx
@@ -757,8 +757,9 @@ export function DynamicTableEditor(props: DynamicTableEditorProps) {
           choiceGroups={currentQuestion?.choiceGroups}
           onChoiceGroupsChange={(groups: ChoiceGroup[]) => {
             if (!currentQuestionId) return;
-            // 셀 저장 이후 호출되므로 currentRows 는 이미 최신 상태.
-            // prune 은 최신 행 데이터 기준으로 계산한다.
+            // 주의: 모달 handleSave 에서 onSave(셀 반영)보다 먼저 호출된다 —
+            // currentRowsRef 는 이번 셀 변경 이전 상태일 수 있다. DB prune 은
+            // 모달 쪽(updatedRowsData 기준)이 정확하고, 여기는 스토어 표시용 보정.
             const qAfter = {
               ...currentQuestion!,
               tableRowsData: currentRowsRef.current,

--- a/src/components/survey-builder/dynamic-table-editor.tsx
+++ b/src/components/survey-builder/dynamic-table-editor.tsx
@@ -757,8 +757,8 @@ export function DynamicTableEditor(props: DynamicTableEditorProps) {
           choiceGroups={currentQuestion?.choiceGroups}
           onChoiceGroupsChange={(groups: ChoiceGroup[]) => {
             if (!currentQuestionId) return;
-            // 주의: 모달 handleSave 에서 onSave(셀 반영)보다 먼저 호출된다 —
-            // currentRowsRef 는 이번 셀 변경 이전 상태일 수 있다. DB prune 은
+            // 모달 handleSave 에서 onSave(셀 반영) 이후에 호출된다 —
+            // currentRowsRef 는 이번 셀 변경을 이미 반영한 상태. DB prune 은
             // 모달 쪽(updatedRowsData 기준)이 정확하고, 여기는 스토어 표시용 보정.
             const qAfter = {
               ...currentQuestion!,

--- a/src/components/survey-builder/dynamic-table-editor.tsx
+++ b/src/components/survey-builder/dynamic-table-editor.tsx
@@ -11,7 +11,8 @@ import { Label } from '@/components/ui/label';
 import { generateId } from '@/lib/utils';
 import { useSurveyBuilderStore } from '@/stores/survey-store';
 import { useSurveyUIStore } from '@/stores/ui-store';
-import { DynamicRowGroupConfig, HeaderCell, QuestionConditionGroup, TableCell, TableColumn, TableRow } from '@/types/survey';
+import { ChoiceGroup, DynamicRowGroupConfig, HeaderCell, QuestionConditionGroup, TableCell, TableColumn, TableRow } from '@/types/survey';
+import { pruneChoiceGroups } from '@/utils/choice-group-helpers';
 
 import { BulkGeneratorModal, BulkColumnDef } from './bulk-generator';
 import { CellContentModal } from './cell-content-modal';
@@ -753,6 +754,21 @@ export function DynamicTableEditor(props: DynamicTableEditorProps) {
           columnCode={selectedCellContext.columnCode}
           columnLabel={selectedCellContext.columnLabel}
           cell={selectedCellContext.cell}
+          choiceGroups={currentQuestion?.choiceGroups}
+          onChoiceGroupsChange={(groups: ChoiceGroup[]) => {
+            if (!currentQuestionId) return;
+            // 셀 저장 이후 호출되므로 currentRows 는 이미 최신 상태.
+            // prune 은 최신 행 데이터 기준으로 계산한다.
+            const qAfter = {
+              ...currentQuestion!,
+              tableRowsData: currentRowsRef.current,
+              choiceGroups: groups,
+            };
+            const pruned = pruneChoiceGroups(qAfter);
+            silentUpdateQuestion(currentQuestionId, {
+              ...(pruned !== undefined ? { choiceGroups: pruned } : { choiceGroups: [] }),
+            });
+          }}
           onSave={(cell) => {
             if (selectedCellContext.rowIndex !== -1 && selectedCellContext.cellIndex !== -1) {
               updateCell(selectedCellContext.rowIndex, selectedCellContext.cellIndex, cell);

--- a/src/components/survey-builder/hooks/use-cell-form.ts
+++ b/src/components/survey-builder/hooks/use-cell-form.ts
@@ -65,6 +65,7 @@ export interface CellFormSetters {
   setChoiceLabel: (v: string) => void;
   setChoiceAllowTextInput: (v: boolean) => void;
   setChoiceBranchRule: (v: CellFormState['choiceBranchRule']) => void;
+  setChoiceGroupId: (v: string) => void;
   setHorizontalAlign: (v: 'left' | 'center' | 'right') => void;
   setMobileDisplay: (v: CellFormState['mobileDisplay']) => void;
   setVerticalAlign: (v: 'top' | 'middle' | 'bottom') => void;
@@ -139,6 +140,7 @@ export function useCellForm(cell: TableCell, isOpen: boolean): UseCellFormResult
       setChoiceLabel: set('choiceLabel'),
       setChoiceAllowTextInput: set('choiceAllowTextInput'),
       setChoiceBranchRule: set('choiceBranchRule'),
+      setChoiceGroupId: set('choiceGroupId'),
       setHorizontalAlign: set('horizontalAlign'),
       setMobileDisplay: set('mobileDisplay'),
       setVerticalAlign: set('verticalAlign'),

--- a/src/components/survey-builder/question-test-card.tsx
+++ b/src/components/survey-builder/question-test-card.tsx
@@ -443,7 +443,7 @@ function QuestionTestInput({
       <ChoiceTableResponse
         question={question}
         value={value}
-        onChange={onChange as (v: string | string[] | null) => void}
+        onChange={onChange as (v: unknown) => void}
       />
     );
   }

--- a/src/components/survey-response/choice-table-response.tsx
+++ b/src/components/survey-response/choice-table-response.tsx
@@ -121,9 +121,10 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
           aria-label={option?.label ?? '선택'}
           checked={checked}
           disabled={disabled}
-          // radio 재클릭(이미 선택된 셀) 은 onChange 가 발화하지 않으므로 onClick 에서 토글 처리.
-          onClick={!isCheckbox ? () => toggle(cell.id, !checked) : undefined}
-          onChange={isCheckbox ? (e) => toggle(cell.id, e.target.checked) : undefined}
+          // 그룹 모드 radio 재클릭(이미 선택된 셀) 은 onChange 가 발화하지 않으므로
+          // onClick 에서 토글 해제 처리. 비그룹 radio 는 기존대로 해제 불가(onChange만).
+          onClick={isGrouped ? () => toggle(cell.id, !checked) : undefined}
+          onChange={!isGrouped || isCheckbox ? (e) => toggle(cell.id, e.target.checked) : undefined}
           className="h-4 w-4"
         />
         {option?.allowTextInput && checked && (
@@ -182,9 +183,9 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
                       aria-label={cardLabel}
                       checked={checked}
                       disabled={disabled}
-                      // radio 재클릭은 onChange 미발화 — onClick 에서 토글 처리
-                      onClick={!isCheckbox ? () => toggle(choiceCell.id, !checked) : undefined}
-                      onChange={isCheckbox ? (e) => toggle(choiceCell.id, e.target.checked) : undefined}
+                      // 그룹 모드 radio 만 onClick 토글 해제. 비그룹은 기존 onChange 경로 유지.
+                      onClick={isGrouped ? () => toggle(choiceCell.id, !checked) : undefined}
+                      onChange={!isGrouped || isCheckbox ? (e) => toggle(choiceCell.id, e.target.checked) : undefined}
                       className="h-5 w-5"
                     />
                   }

--- a/src/components/survey-response/choice-table-response.tsx
+++ b/src/components/survey-response/choice-table-response.tsx
@@ -8,6 +8,11 @@ import { useContactAttrs } from '@/lib/survey/contact-attrs-context';
 import { substituteTokens } from '@/lib/survey/substitute-tokens';
 import type { Question, TableCell } from '@/types/survey';
 import { resolveChoiceOptions } from '@/utils/choice-source';
+import {
+  isGroupedChoiceQuestion,
+  getGroupKeyOfCell,
+  type GroupedChoiceAnswer,
+} from '@/utils/choice-group-helpers';
 import { findMobileHeaderCell } from '@/utils/mobile-display-cells';
 
 import { MobileOptionCard } from './mobile-card-shared';
@@ -15,9 +20,12 @@ import { OptionTextInput } from './option-text-input';
 
 interface ChoiceTableResponseProps {
   question: Question;
-  /** radio: string | null, checkbox: string[] */
+  /**
+   * radio: string | null (비그룹), GroupedChoiceAnswer (그룹별 선택)
+   * checkbox: string[]
+   */
   value: unknown;
-  onChange: (value: string | string[] | null) => void;
+  onChange: (value: string | string[] | GroupedChoiceAnswer | null) => void;
 }
 
 /**
@@ -28,6 +36,8 @@ interface ChoiceTableResponseProps {
  */
 export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableResponseProps) {
   const isCheckbox = question.type === 'checkbox';
+  // 그룹별 선택 모드 여부 — radio + choiceGroups 1개 이상 정의된 경우만 true
+  const isGrouped = !isCheckbox && isGroupedChoiceQuestion(question);
   const isMobile = useMobileView();
   const attrs = useContactAttrs();
   const options = useMemo(() => resolveChoiceOptions(question), [question]);
@@ -36,10 +46,15 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
     [options],
   );
 
+  // checkbox: cell.id[] / 비그룹 radio: [선택 cellId] / 그룹별 radio: 맵에서 values 추출
   const selectedIds: string[] = useMemo(() => {
     if (isCheckbox) return Array.isArray(value) ? (value as string[]) : [];
+    if (isGrouped) {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) return [];
+      return Object.values(value as GroupedChoiceAnswer).filter(Boolean);
+    }
     return typeof value === 'string' && value ? [value] : [];
-  }, [isCheckbox, value]);
+  }, [isCheckbox, isGrouped, value]);
 
   const minSel = question.minSelections;
   const maxSel = question.maxSelections;
@@ -47,6 +62,21 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
     isCheckbox && maxSel !== undefined && maxSel > 0 && selectedIds.length >= maxSel;
 
   const toggle = (cellId: string, checked: boolean) => {
+    if (isGrouped) {
+      // 그룹별 선택: 같은 그룹 내에서 교체, 재클릭 시 해제(키 삭제)
+      const groupKey = getGroupKeyOfCell(question, cellId);
+      const map = (value && typeof value === 'object' && !Array.isArray(value)
+        ? (value as GroupedChoiceAnswer)
+        : {}) as GroupedChoiceAnswer;
+      if (map[groupKey] === cellId) {
+        // 재클릭 해제 — 해당 키 삭제
+        const { [groupKey]: _removed, ...rest } = map;
+        onChange(rest as GroupedChoiceAnswer);
+      } else {
+        onChange({ ...map, [groupKey]: cellId });
+      }
+      return;
+    }
     if (!isCheckbox) {
       onChange(checked ? cellId : null);
       return;
@@ -62,7 +92,12 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
   };
 
   const getChoiceCellState = (cell: TableCell) => {
-    const checked = selectedIds.includes(cell.id);
+    const checked = isGrouped
+      ? // 그룹별 선택: 그룹 키의 현재 선택값이 이 셀인지 확인
+        (value && typeof value === 'object' && !Array.isArray(value)
+          ? (value as GroupedChoiceAnswer)[getGroupKeyOfCell(question, cell.id)] === cell.id
+          : false)
+      : selectedIds.includes(cell.id);
     return {
       checked,
       disabled: isMaxSelectionReached && !checked,
@@ -73,16 +108,22 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
   const renderCell = (cell: TableCell): ReactNode => {
     if (cell.type !== 'choice_opt' || cell.isHidden) return undefined;
     const { checked, disabled, option } = getChoiceCellState(cell);
+    // 그룹별 선택 모드: radio name 을 그룹 키 단위로 분리해야 브라우저가 그룹 간 선택을 지우지 않는다.
+    const inputName = isGrouped
+      ? `${question.id}-${getGroupKeyOfCell(question, cell.id)}`
+      : question.id;
 
     return (
       <div className="flex flex-col items-center gap-2">
         <input
           type={isCheckbox ? 'checkbox' : 'radio'}
-          name={question.id}
+          name={inputName}
           aria-label={option?.label ?? '선택'}
           checked={checked}
           disabled={disabled}
-          onChange={(e) => toggle(cell.id, e.target.checked)}
+          // radio 재클릭(이미 선택된 셀) 은 onChange 가 발화하지 않으므로 onClick 에서 토글 처리.
+          onClick={!isCheckbox ? () => toggle(cell.id, !checked) : undefined}
+          onChange={isCheckbox ? (e) => toggle(cell.id, e.target.checked) : undefined}
           className="h-4 w-4"
         />
         {option?.allowTextInput && checked && (
@@ -122,6 +163,10 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
               const cardLabel = headerText
                 ? substituteTokens(headerText, attrs)
                 : (option?.label ?? '(라벨 없음)');
+              // 그룹별 선택 모드: radio name 을 그룹 키 단위로 분리
+              const mobileInputName = isGrouped
+                ? `${question.id}-${getGroupKeyOfCell(question, choiceCell.id)}`
+                : question.id;
               return (
                 <MobileOptionCard
                   key={choiceCell.id}
@@ -133,11 +178,13 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
                   control={
                     <input
                       type={isCheckbox ? 'checkbox' : 'radio'}
-                      name={question.id}
+                      name={mobileInputName}
                       aria-label={cardLabel}
                       checked={checked}
                       disabled={disabled}
-                      onChange={(e) => toggle(choiceCell.id, e.target.checked)}
+                      // radio 재클릭은 onChange 미발화 — onClick 에서 토글 처리
+                      onClick={!isCheckbox ? () => toggle(choiceCell.id, !checked) : undefined}
+                      onChange={isCheckbox ? (e) => toggle(choiceCell.id, e.target.checked) : undefined}
                       className="h-5 w-5"
                     />
                   }

--- a/src/components/survey-response/question-input.tsx
+++ b/src/components/survey-response/question-input.tsx
@@ -72,7 +72,7 @@ export function QuestionInput({
       <ChoiceTableResponse
         question={question}
         value={value}
-        onChange={onChange as (v: string | string[] | null) => void}
+        onChange={onChange as (v: unknown) => void}
       />
     );
   }

--- a/src/lib/analytics/raw-export-helpers.ts
+++ b/src/lib/analytics/raw-export-helpers.ts
@@ -69,6 +69,14 @@ export function buildCodebookValueLabel(
       }
       return '';
 
+    case 'choice-group':
+      if (col.choiceGroupValueLabels && col.choiceGroupValueLabels.length > 0) {
+        return col.choiceGroupValueLabels
+          .map(({ value, label }) => `${value}=${label}`)
+          .join(', ');
+      }
+      return '';
+
     case 'ranking-rank':
     case 'table-cell-ranking': {
       const opts = col.cellOptions ?? (q ? resolveRankingOptions(q) : []);

--- a/src/lib/analytics/spss-excel-export.ts
+++ b/src/lib/analytics/spss-excel-export.ts
@@ -184,8 +184,9 @@ export function generateSPSSColumns(questions: Question[]): SPSSExportColumn[] {
           });
         });
         const isDefault = group.groupKey === DEFAULT_GROUP_KEY;
+        const groupVarName = isDefault ? q.questionCode : `${q.questionCode}_${group.groupKey}`;
         columns.push({
-          spssVarName: isDefault ? q.questionCode : `${q.questionCode}_${group.groupKey}`,
+          spssVarName: groupVarName,
           questionText: q.title,
           optionLabel: group.label || q.title,
           questionId: q.id,
@@ -193,6 +194,21 @@ export function generateSPSSColumns(questions: Question[]): SPSSExportColumn[] {
           choiceGroupKey: group.groupKey,
           choiceGroupCellValueMap: cellValueMap,
           choiceGroupValueLabels: valueLabels,
+        });
+        // allowTextInput 멤버 셀마다 STRING 사이드카 텍스트 변수 생성.
+        // 저장 경로는 __optTexts__[questionId][cell.id] 로 비그룹과 동일하므로
+        // optionId=cell.id 를 그대로 사용해 기존 option-text 추출 case 가 동작한다.
+        group.cells.forEach((cell, idx) => {
+          if (!cell.allowTextInput) return;
+          const varNumber = cell.spssNumericCode != null ? String(cell.spssNumericCode) : String(idx + 1);
+          columns.push({
+            spssVarName: buildOptionTextVarName(groupVarName, varNumber),
+            questionText: q.title,
+            optionLabel: `${(cell.choiceLabel ?? '').trim() || (cell.content ?? '').trim() || '(라벨 없음)'} (텍스트)`,
+            questionId: q.id,
+            type: 'option-text',
+            optionId: cell.id,
+          });
         });
       }
     } else if (q.type === 'radio' || q.type === 'select') {

--- a/src/lib/analytics/spss-excel-export.ts
+++ b/src/lib/analytics/spss-excel-export.ts
@@ -33,6 +33,11 @@ import {
   generateExportLabel,
   resolveRankVarName,
 } from '@/utils/table-cell-code-generator';
+import {
+  collectRadioGroups,
+  DEFAULT_GROUP_KEY,
+  isGroupedChoiceQuestion,
+} from '@/utils/choice-group-helpers';
 
 export interface SPSSExportColumn {
   spssVarName: string;
@@ -54,7 +59,8 @@ export interface SPSSExportColumn {
     | 'table-cell-ranking'
     | 'table-cell-ranking-other'
     | 'option-text'
-    | 'table-cell-option-text';
+    | 'table-cell-option-text'
+    | 'choice-group';
   optionIndex?: number;
   optionValue?: string;
   tableCellId?: string;
@@ -82,6 +88,13 @@ export interface SPSSExportColumn {
   cellExportLabel?: string;
   // 'text' 컬럼 전용: 숫자 단답형(question.inputType==='number') 이면 Numeric 변수로 처리
   numericText?: boolean;
+  // === 'choice-group' 전용: radio choiceGroups 기반 그룹별 단일선택 변수 ===
+  // 이 변수가 담당하는 그룹의 groupKey
+  choiceGroupKey?: string;
+  // 멤버 셀 id → 응답 시 기록할 숫자값 (spssNumericCode 또는 그룹 내 1-based 순서 폴백)
+  choiceGroupCellValueMap?: Record<string, number>;
+  // 숫자값 → SPSS VALUE LABEL 배열
+  choiceGroupValueLabels?: Array<{ value: number; label: string }>;
 }
 
 /**
@@ -155,6 +168,31 @@ export function generateSPSSColumns(questions: Question[]): SPSSExportColumn[] {
           optionLabel: '기타 입력',
           questionId: q.id,
           type: 'other-text',
+        });
+      }
+    } else if (q.type === 'radio' && isGroupedChoiceQuestion(q)) {
+      // choiceGroups 기반 radio — 그룹별 변수 1개씩 생성
+      for (const group of collectRadioGroups(q)) {
+        const cellValueMap: Record<string, number> = {};
+        const valueLabels: Array<{ value: number; label: string }> = [];
+        group.cells.forEach((cell, idx) => {
+          const code = cell.spssNumericCode ?? idx + 1;
+          cellValueMap[cell.id] = code;
+          valueLabels.push({
+            value: code,
+            label: (cell.choiceLabel ?? '').trim() || (cell.content ?? '').trim() || '(라벨 없음)',
+          });
+        });
+        const isDefault = group.groupKey === DEFAULT_GROUP_KEY;
+        columns.push({
+          spssVarName: isDefault ? q.questionCode : `${q.questionCode}_${group.groupKey}`,
+          questionText: q.title,
+          optionLabel: group.label || q.title,
+          questionId: q.id,
+          type: 'choice-group',
+          choiceGroupKey: group.groupKey,
+          choiceGroupCellValueMap: cellValueMap,
+          choiceGroupValueLabels: valueLabels,
         });
       }
     } else if (q.type === 'radio' || q.type === 'select') {
@@ -701,6 +739,16 @@ export function buildDataRow(
         }
 
         return transformTableChoiceCell(col.tableCellType || 'input', cellVal, col.cellOptions);
+      }
+
+      case 'choice-group': {
+        // rawValue는 그룹별 응답 맵: { groupKey: selectedCellId, ... }
+        // 해당 그룹의 선택 cellId를 꺼내 cellValueMap으로 숫자코드로 변환.
+        if (rawValue == null || typeof rawValue !== 'object' || Array.isArray(rawValue)) return null;
+        const groupAnswer = rawValue as Record<string, string>;
+        const cellId = groupAnswer[col.choiceGroupKey ?? ''];
+        if (!cellId) return null;
+        return col.choiceGroupCellValueMap?.[cellId] ?? null;
       }
 
       case 'radio-group': {

--- a/src/lib/spss/sav-builder.ts
+++ b/src/lib/spss/sav-builder.ts
@@ -73,6 +73,12 @@ export function buildValueLabels(
         .sort((a, b) => Number(a.value) - Number(b.value));
     }
 
+    case 'choice-group': {
+      // choice-group: generateSPSSColumns가 미리 계산한 choiceGroupValueLabels를 그대로 사용.
+      if (!col.choiceGroupValueLabels || col.choiceGroupValueLabels.length === 0) return undefined;
+      return [...col.choiceGroupValueLabels].sort((a, b) => a.value - b.value);
+    }
+
     case 'table-cell': {
       if (col.tableCellType === 'input') return undefined;
 

--- a/src/lib/spss/variable-meta.ts
+++ b/src/lib/spss/variable-meta.ts
@@ -34,6 +34,7 @@ export function resolveVarType(col: SPSSExportColumn, question: Question | undef
     case 'notice-agree':
     case 'ranking-rank':
     case 'radio-group':
+    case 'choice-group':
     case 'table-cell-ranking':
       return VariableType.Numeric;
 
@@ -86,6 +87,11 @@ export function resolveMeasure(col: SPSSExportColumn, question: Question | undef
     return VariableMeasure.Ordinal;
   }
 
+  // choice-group (질문 레벨 choiceGroups 기반 단일선택) — 명목척도
+  if (col.type === 'choice-group') {
+    return VariableMeasure.Nominal;
+  }
+
   // 숫자 단답형(numericText) 은 척도(Continuous)
   if (col.type === 'text' && col.numericText) {
     return VariableMeasure.Continuous;
@@ -135,6 +141,7 @@ export function buildLabel(col: SPSSExportColumn): string {
         ? `${col.questionText} - ${col.optionLabel}`
         : col.questionText;
     case 'radio-group':
+    case 'choice-group':
       return col.optionLabel
         ? `${col.questionText} - ${col.optionLabel}`
         : col.questionText;

--- a/src/lib/survey/answer-validation.ts
+++ b/src/lib/survey/answer-validation.ts
@@ -1,4 +1,8 @@
 import type { Question } from '@/types/survey';
+import {
+  isGroupedChoiceQuestion,
+  collectRadioGroups,
+} from '@/utils/choice-group-helpers';
 
 /**
  * 질문 타입별 응답 충족 여부를 판정하는 순수 함수.
@@ -36,6 +40,14 @@ export function isQuestionAnswered(question: Question, response: unknown): boole
     case 'textarea':
       return typeof response === 'string' && response.trim().length > 0;
     case 'radio':
+      // 그룹별 선택 radio: 모든 그룹(default 포함)에 선택이 있어야 충족
+      if (isGroupedChoiceQuestion(question)) {
+        const map = (response ?? {}) as Record<string, unknown>;
+        return collectRadioGroups(question).every(
+          (g) => typeof map[g.groupKey] === 'string' && map[g.groupKey] !== '',
+        );
+      }
+      return response !== null && response !== undefined && response !== '';
     case 'select':
       return response !== null && response !== undefined && response !== '';
     case 'checkbox':

--- a/src/utils/branch-logic.ts
+++ b/src/utils/branch-logic.ts
@@ -18,6 +18,7 @@ import { evaluateComparisonWithFailSafe, type ComparisonResult } from '@/lib/loo
 import { evaluateRightOperand } from '@/lib/lookup/evaluate-lookup';
 import type { LookupEvalCtx } from '@/lib/lookup/types';
 import { resolveChoiceOptions } from '@/utils/choice-source';
+import { isGroupedChoiceQuestion } from '@/utils/choice-group-helpers';
 
 // numeric-input 의 parseNumericInput 는 evaluateComparisonWithFailSafe 내부 (evaluate-arith) 에서 사용.
 
@@ -128,12 +129,28 @@ function getBranchRuleForRanking(question: Question, response: unknown): BranchR
 }
 
 /**
- * 라디오 버튼 응답의 분기 규칙 찾기
+ * 라디오 버튼 응답의 분기 규칙 찾기.
+ * 그룹별 선택(GroupedChoiceAnswer) 응답 맵도 지원한다.
+ * 맵의 경우 선택된 모든 cell.id 중 branchRule 이 있는 첫 번째 옵션을 반환한다.
  */
 function getBranchRuleForRadio(question: Question, response: unknown): BranchRule | null {
   // manual: question.options 그대로 / table-source: choice_opt 셀에서 변환된 옵션
   const options = resolveChoiceOptions(question);
   if (!options.length) return null;
+
+  // 그룹별 선택 모드: 응답 맵의 값 목록(선택 cell.id 들)을 대상으로 검색
+  if (
+    isGroupedChoiceQuestion(question) &&
+    typeof response === 'object' &&
+    response !== null &&
+    !Array.isArray(response)
+  ) {
+    const selectedValues = Object.values(response as Record<string, string>);
+    const selectedOption = options.find(
+      (opt) => selectedValues.includes(opt.value as string) && opt.branchRule,
+    );
+    return selectedOption?.branchRule ?? null;
+  }
 
   // 응답이 객체인 경우 (기타 옵션)
   const selectedValue =

--- a/src/utils/choice-group-helpers.ts
+++ b/src/utils/choice-group-helpers.ts
@@ -41,6 +41,9 @@ export function collectRadioGroups(question: Question): RadioGroupWithCells[] {
   for (const group of question.choiceGroups ?? []) {
     if (group.type !== 'radio') continue;
     const cells = allCells.filter((c) => c.choiceGroupId === group.id);
+    // 멤버 0 그룹은 응답 불가능한 요구가 되므로 제외한다 — 행/열 삭제 등으로
+    // prune 을 비껴간 phantom 그룹(이미 snapshot 에 박힌 것 포함)을 무해화.
+    if (cells.length === 0) continue;
     for (const c of cells) claimed.add(c.id);
     groups.push({ groupKey: group.groupKey, label: group.label, cells });
   }

--- a/src/utils/choice-group-helpers.ts
+++ b/src/utils/choice-group-helpers.ts
@@ -1,0 +1,86 @@
+import type { ChoiceGroup, Question, TableCell } from '@/types/survey';
+import { collectChoiceOptCells } from '@/utils/choice-source';
+
+/** 그룹 미소속 choice_opt 셀의 예약 응답 키. export 변수명은 질문코드 그대로(하위호환). */
+export const DEFAULT_GROUP_KEY = 'default';
+
+/** 그룹별 응답 맵 shape: { groupKey: 선택 cellId } */
+export type GroupedChoiceAnswer = Record<string, string>;
+
+/**
+ * 이 질문의 응답이 그룹별 맵 shape인지 — 모든 경로(렌더/검증/분기/export)의
+ * 하위호환 분기점. radio 그룹이 1개 이상 정의된 경우에만 true.
+ */
+export function isGroupedChoiceQuestion(question: Question): boolean {
+  return (question.choiceGroups ?? []).some((g) => g.type === 'radio');
+}
+
+/** 셀이 속한 그룹의 groupKey. 미소속/깨진 참조는 default로 폴백. */
+export function getGroupKeyOfCell(question: Question, cellId: string): string {
+  const cell = collectChoiceOptCells(question.tableRowsData).find((c) => c.id === cellId);
+  if (!cell?.choiceGroupId) return DEFAULT_GROUP_KEY;
+  const group = (question.choiceGroups ?? []).find((g) => g.id === cell.choiceGroupId);
+  return group?.groupKey ?? DEFAULT_GROUP_KEY;
+}
+
+export interface RadioGroupWithCells {
+  groupKey: string;
+  label: string;
+  cells: TableCell[];
+}
+
+/**
+ * 질문의 radio 그룹들을 멤버 셀과 함께 반환한다 (정의 순).
+ * 미소속 choice_opt 셀이 있으면 default 그룹을 마지막에 추가한다.
+ */
+export function collectRadioGroups(question: Question): RadioGroupWithCells[] {
+  const allCells = collectChoiceOptCells(question.tableRowsData);
+  const groups: RadioGroupWithCells[] = [];
+  const claimed = new Set<string>();
+
+  for (const group of question.choiceGroups ?? []) {
+    if (group.type !== 'radio') continue;
+    const cells = allCells.filter((c) => c.choiceGroupId === group.id);
+    for (const c of cells) claimed.add(c.id);
+    groups.push({ groupKey: group.groupKey, label: group.label, cells });
+  }
+
+  const orphans = allCells.filter((c) => !claimed.has(c.id));
+  if (orphans.length > 0) {
+    groups.push({ groupKey: DEFAULT_GROUP_KEY, label: '', cells: orphans });
+  }
+  return groups;
+}
+
+const KEY_PREFIX: Record<ChoiceGroup['type'], string> = {
+  radio: 'rad',
+  checkbox: 'cb',
+  ranking: 'rnk',
+};
+
+/** 그룹 키 자동 발번: 같은 종류의 최대 순번 + 1 (rad1, rad2 ...) */
+export function nextGroupKey(groups: ChoiceGroup[], type: ChoiceGroup['type']): string {
+  const prefix = KEY_PREFIX[type];
+  let max = 0;
+  for (const g of groups) {
+    const m = g.groupKey.match(new RegExp(`^${prefix}(\\d+)$`));
+    if (m) max = Math.max(max, Number(m[1]));
+  }
+  return `${prefix}${max + 1}`;
+}
+
+/**
+ * 멤버 0 그룹을 제거한 choiceGroups를 반환한다 (저장 시 자동 정리 — 삭제 UI 없음).
+ * 변경 없으면 원본 참조 유지, choiceGroups 자체가 없으면 undefined.
+ */
+export function pruneChoiceGroups(question: Question): ChoiceGroup[] | undefined {
+  const groups = question.choiceGroups;
+  if (!groups) return undefined;
+  const memberIds = new Set(
+    collectChoiceOptCells(question.tableRowsData)
+      .map((c) => c.choiceGroupId)
+      .filter((id): id is string => !!id),
+  );
+  const pruned = groups.filter((g) => memberIds.has(g.id));
+  return pruned.length === groups.length ? groups : pruned;
+}

--- a/src/utils/serialize-cell.ts
+++ b/src/utils/serialize-cell.ts
@@ -45,6 +45,8 @@ export interface CellFormState {
   choiceLabel: string;
   choiceAllowTextInput: boolean;
   choiceBranchRule: BranchRule | undefined;
+  /** 이 보기 옵션 셀이 속한 ChoiceGroup.id. 빈 문자열 = 미소속. */
+  choiceGroupId: string;
   horizontalAlign: 'left' | 'center' | 'right';
   mobileDisplay: NonNullable<TableCell['mobileDisplay']>;
   verticalAlign: 'top' | 'middle' | 'bottom';
@@ -119,6 +121,7 @@ export function cellToFormState(cell: TableCell): CellFormState {
     choiceLabel: cell.choiceLabel || '',
     choiceAllowTextInput: cell.allowTextInput === true,
     choiceBranchRule: cell.branchRule,
+    choiceGroupId: cell.choiceGroupId ?? '',
     horizontalAlign: cell.horizontalAlign || 'left',
     mobileDisplay: cell.mobileDisplay ?? 'hidden',
     verticalAlign: cell.verticalAlign || 'top',
@@ -234,6 +237,11 @@ export function buildUpdatedCell(form: CellFormState, cell: TableCell): TableCel
           ...(form.choiceBranchRule
             ? { branchRule: { ...form.choiceBranchRule, value: cell.id } }
             : {}),
+          // 그룹 귀속. 빈 문자열이면 기존 셀에 있던 choiceGroupId 도 제거된다.
+          // (choice_opt block 이 cellBase spread 이후에 위치하므로 빈 값 시
+          //  명시적으로 undefined 를 넣어 키를 덮어쓴다 — exactOptionalPropertyTypes 준수를 위해
+          //  후처리 delete 방식 대신 아래 updatedCell 후처리를 사용한다.)
+          ...(form.choiceGroupId ? { choiceGroupId: form.choiceGroupId } : {}),
         }
       : {}),
     // 셀 병합 속성 추가
@@ -275,6 +283,12 @@ export function buildUpdatedCell(form: CellFormState, cell: TableCell): TableCel
         }
       : {}),
   };
+
+  // choice_opt 에서 그룹 해제(빈 문자열)를 선택했을 때, cellBase spread 로 남아있을 수 있는
+  // choiceGroupId 를 제거한다. exactOptionalPropertyTypes 상 undefined 할당은 금지이므로 delete 사용.
+  if (contentType === 'choice_opt' && !form.choiceGroupId) {
+    delete (updatedCell as Partial<TableCell>).choiceGroupId;
+  }
 
   return updatedCell;
 }

--- a/tests/integration/choice-table-response.test.ts
+++ b/tests/integration/choice-table-response.test.ts
@@ -100,6 +100,72 @@ describe('choice table-source checkbox 집계', () => {
   });
 });
 
+/**
+ * 그룹별 선택 radio: getBranchRuleForResponse 가 grouped 응답 맵을 처리한다.
+ * 맵의 값들(선택 cell.id 목록) 중 branchRule 이 있는 첫 번째 옵션을 반환.
+ */
+function groupedBranchQ(): Question {
+  return {
+    id: 'qg',
+    type: 'radio',
+    title: '그룹 분기 라디오',
+    required: false,
+    order: 0,
+    tableColumns: [{ id: 'c1', label: '열' }],
+    tableRowsData: [
+      {
+        id: 'row1',
+        label: '',
+        cells: [
+          {
+            id: 'cellA',
+            type: 'choice_opt',
+            content: '',
+            choiceGroupId: 'grp1',
+            branchRule: { id: 'b1', value: 'cellA', action: 'end' },
+          },
+          {
+            id: 'cellB',
+            type: 'choice_opt',
+            content: '',
+            choiceGroupId: 'grp1',
+          },
+          {
+            id: 'cellC',
+            type: 'choice_opt',
+            content: '',
+            choiceGroupId: 'grp2',
+          },
+        ],
+      },
+    ],
+    choiceGroups: [
+      { id: 'grp1', type: 'radio', groupKey: 'rad1', label: '그룹1' },
+      { id: 'grp2', type: 'radio', groupKey: 'rad2', label: '그룹2' },
+    ],
+  } as unknown as Question;
+}
+
+describe('그룹별 선택 radio 분기 로직', () => {
+  it('grouped 응답 맵에서 branchRule 있는 선택 셀의 규칙을 반환한다', () => {
+    const q = groupedBranchQ();
+    const rule = getBranchRuleForResponse(q, { rad1: 'cellA', rad2: 'cellC' });
+    expect(rule?.action).toBe('end');
+  });
+
+  it('branchRule 없는 셀만 선택된 경우 null 반환', () => {
+    const q = groupedBranchQ();
+    const rule = getBranchRuleForResponse(q, { rad1: 'cellB', rad2: 'cellC' });
+    expect(rule).toBeNull();
+  });
+
+  it('빈 맵({})이면 null 반환', () => {
+    const q = groupedBranchQ();
+    const rule = getBranchRuleForResponse(q, {});
+    expect(rule).toBeNull();
+  });
+});
+
 describe('choice table-source SPSS 단일/복수 변수 계약', () => {
   function radioTableQ(): Question {
     return {

--- a/tests/unit/answer-validation.test.ts
+++ b/tests/unit/answer-validation.test.ts
@@ -17,6 +17,37 @@ function q(type: QuestionType, overrides: Partial<Question> = {}): Question {
   };
 }
 
+/**
+ * 그룹별 선택 radio 질문 빌더.
+ * rad1(cellA, cellB), rad2(cellC), 미소속 default(cellD)
+ */
+function groupedRadioQ(): Question {
+  return {
+    id: 'qg',
+    type: 'radio',
+    title: '그룹 라디오',
+    required: true,
+    order: 0,
+    tableColumns: [{ id: 'c1', label: '열' }],
+    tableRowsData: [
+      {
+        id: 'r1',
+        label: '',
+        cells: [
+          { id: 'cellA', type: 'choice_opt', content: '', choiceGroupId: 'grp1' },
+          { id: 'cellB', type: 'choice_opt', content: '', choiceGroupId: 'grp1' },
+          { id: 'cellC', type: 'choice_opt', content: '', choiceGroupId: 'grp2' },
+          { id: 'cellD', type: 'choice_opt', content: '' },
+        ],
+      },
+    ],
+    choiceGroups: [
+      { id: 'grp1', type: 'radio', groupKey: 'rad1', label: '그룹1' },
+      { id: 'grp2', type: 'radio', groupKey: 'rad2', label: '그룹2' },
+    ],
+  } as unknown as Question;
+}
+
 describe('isQuestionAnswered (survey-response-flow 추출 characterization)', () => {
   // 모든 타입 공통: null/undefined 응답은 미응답.
   it('응답값이 undefined/null 이면 모든 타입에서 미응답', () => {
@@ -157,5 +188,36 @@ describe('isQuestionAnswered (survey-response-flow 추출 characterization)', ()
       expect(isQuestionAnswered(n, {})).toBe(false);
       expect(isQuestionAnswered(n, false)).toBe(false);
     });
+  });
+});
+
+describe('isQuestionAnswered — 그룹별 선택 radio (choiceGroups)', () => {
+  it('모든 그룹(rad1, rad2, default)에 선택이 있어야 응답 충족', () => {
+    const gq = groupedRadioQ();
+    expect(
+      isQuestionAnswered(gq, { rad1: 'cellA', rad2: 'cellC', default: 'cellD' }),
+    ).toBe(true);
+  });
+
+  it('일부 그룹만 선택된 경우 미응답', () => {
+    const gq = groupedRadioQ();
+    // rad1만 선택, rad2/default 누락
+    expect(isQuestionAnswered(gq, { rad1: 'cellA' })).toBe(false);
+  });
+
+  it('빈 맵({})은 미응답', () => {
+    const gq = groupedRadioQ();
+    expect(isQuestionAnswered(gq, {})).toBe(false);
+  });
+
+  it('undefined/null 은 미응답', () => {
+    const gq = groupedRadioQ();
+    expect(isQuestionAnswered(gq, undefined)).toBe(false);
+    expect(isQuestionAnswered(gq, null)).toBe(false);
+  });
+
+  it('비그룹 radio 기존 동작 유지: 문자열이면 응답', () => {
+    expect(isQuestionAnswered(q('radio'), 'opt1')).toBe(true);
+    expect(isQuestionAnswered(q('radio'), '')).toBe(false);
   });
 });

--- a/tests/unit/answer-validation.test.ts
+++ b/tests/unit/answer-validation.test.ts
@@ -220,4 +220,34 @@ describe('isQuestionAnswered — 그룹별 선택 radio (choiceGroups)', () => {
     expect(isQuestionAnswered(q('radio'), 'opt1')).toBe(true);
     expect(isQuestionAnswered(q('radio'), '')).toBe(false);
   });
+
+  it('phantom 그룹(멤버 0) 이 있어도 살아있는 그룹만 채우면 isQuestionAnswered=true', () => {
+    // rad2 는 멤버가 없는 phantom — collectRadioGroups 가 제외하므로 요구 그룹이 줄어든다.
+    const withPhantom: Question = {
+      id: 'qp',
+      type: 'radio',
+      title: '팬텀 그룹 테스트',
+      required: true,
+      order: 0,
+      tableColumns: [{ id: 'c1', label: '열' }],
+      tableRowsData: [
+        {
+          id: 'r1',
+          label: '',
+          cells: [
+            { id: 'cellA', type: 'choice_opt', content: '', choiceGroupId: 'grp1' },
+            // grp2 에 소속된 셀 없음 — phantom
+          ],
+        },
+      ],
+      choiceGroups: [
+        { id: 'grp1', type: 'radio', groupKey: 'rad1', label: '그룹1' },
+        { id: 'grp2', type: 'radio', groupKey: 'rad2', label: '팬텀' },
+      ],
+    } as unknown as Question;
+    // rad1 만 선택해도 살아있는 그룹은 rad1 뿐이므로 응답 충족
+    expect(isQuestionAnswered(withPhantom, { rad1: 'cellA' })).toBe(true);
+    // 아무것도 선택 안 하면 미응답
+    expect(isQuestionAnswered(withPhantom, {})).toBe(false);
+  });
 });

--- a/tests/unit/domains/spss/choice-group-export.test.ts
+++ b/tests/unit/domains/spss/choice-group-export.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDataRows, generateSPSSColumns } from '@/lib/analytics/spss-excel-export';
+import type { Question, SurveySubmission } from '@/types/survey';
+
+// radio choiceGroups 가 있는 질문 픽스처
+const grouped = {
+  id: 'q1',
+  type: 'radio',
+  title: 'TV 질문',
+  required: false,
+  order: 1,
+  questionCode: 'Q5',
+  choiceGroups: [
+    { id: 'g1', groupKey: 'rad1', type: 'radio', label: 'TV보유' },
+    { id: 'g2', groupKey: 'rad2', type: 'radio', label: '구매의향' },
+  ],
+  tableRowsData: [
+    {
+      id: 'r1',
+      label: '행1',
+      cells: [
+        { id: 'cellA', content: 'UHD', type: 'choice_opt', choiceGroupId: 'g1', spssNumericCode: 1 },
+        { id: 'cellB', content: 'FHD', type: 'choice_opt', choiceGroupId: 'g1', spssNumericCode: 2 },
+        { id: 'cellC', content: '있음', type: 'choice_opt', choiceGroupId: 'g2', spssNumericCode: 1 },
+        { id: 'cellD', content: '기타', type: 'choice_opt' },
+      ],
+    },
+  ],
+} as unknown as Question;
+
+function makeSubmission(questionResponses: Record<string, unknown>): SurveySubmission {
+  return {
+    id: 'sub-1',
+    surveyId: 'sv-1',
+    startedAt: new Date('2025-01-01T00:00:00Z'),
+    completedAt: new Date('2025-01-01T00:01:00Z'),
+    isCompleted: true,
+    currentGroupOrder: 0,
+    questionResponses,
+    updatedAt: new Date('2025-01-01T00:01:00Z'),
+  } as unknown as SurveySubmission;
+}
+
+describe('radio 옵션 그룹 export — generateSPSSColumns', () => {
+  it('그룹별 1변수를 질문코드_groupKey로 생성하고 default 그룹은 질문코드 그대로다', () => {
+    const cols = generateSPSSColumns([grouped]);
+    const names = cols.map((c) => c.spssVarName);
+    expect(names).toContain('Q5_rad1');
+    expect(names).toContain('Q5_rad2');
+    expect(names).toContain('Q5');
+  });
+
+  it('그룹 변수는 cellValueMap으로 멤버 셀 응답값을 매핑한다', () => {
+    const cols = generateSPSSColumns([grouped]);
+    const rad1 = cols.find((c) => c.spssVarName === 'Q5_rad1');
+    expect(rad1?.type).toBe('choice-group');
+    expect(rad1?.choiceGroupCellValueMap).toEqual({ cellA: 1, cellB: 2 });
+  });
+
+  it('value labels는 멤버 셀 라벨을 담는다', () => {
+    const cols = generateSPSSColumns([grouped]);
+    const rad1 = cols.find((c) => c.spssVarName === 'Q5_rad1');
+    expect(rad1?.choiceGroupValueLabels).toEqual([
+      { value: 1, label: 'UHD' },
+      { value: 2, label: 'FHD' },
+    ]);
+  });
+
+  it('그룹 라벨이 변수 라벨 후보(optionLabel)로 전달된다', () => {
+    const cols = generateSPSSColumns([grouped]);
+    const rad1 = cols.find((c) => c.spssVarName === 'Q5_rad1');
+    expect(rad1?.optionLabel).toContain('TV보유');
+  });
+
+  it('choiceGroups 없는 radio 질문은 기존 single 1변수 그대로다 — 하위호환', () => {
+    const plain = { ...grouped, choiceGroups: undefined, id: 'q2', questionCode: 'Q6' } as unknown as Question;
+    const cols = generateSPSSColumns([plain]);
+    expect(cols.filter((c) => c.questionId === 'q2').map((c) => c.type)).toEqual(['single']);
+  });
+});
+
+describe('radio 옵션 그룹 export — buildDataRows 응답값 변환', () => {
+  it('그룹별 응답 맵에서 각 그룹 변수 값을 정확히 추출한다', () => {
+    const cols = generateSPSSColumns([grouped]);
+    // rad1=cellA(1), rad2 미선택, default=cellD
+    const sub = makeSubmission({ q1: { rad1: 'cellA', default: 'cellD' } });
+    const rows = buildDataRows(cols, [grouped], [sub]);
+    const row = rows[0];
+    if (row == null) throw new Error('row 없음');
+    const rad1Col = cols.findIndex((c) => c.spssVarName === 'Q5_rad1');
+    const rad2Col = cols.findIndex((c) => c.spssVarName === 'Q5_rad2');
+    const defCol = cols.findIndex((c) => c.spssVarName === 'Q5');
+
+    expect(row[rad1Col]).toBe(1);    // cellA → spssNumericCode 1
+    expect(row[rad2Col]).toBeNull(); // 미선택
+    // default 그룹 내 cellD는 spssNumericCode 없음 → 그룹 내 1-based 순서(1)
+    expect(row[defCol]).toBe(1);
+  });
+
+  it('응답 없음(null) → null 반환', () => {
+    const cols = generateSPSSColumns([grouped]);
+    const sub = makeSubmission({ q1: null });
+    const rows = buildDataRows(cols, [grouped], [sub]);
+    const row = rows[0];
+    if (row == null) throw new Error('row 없음');
+    const rad1Col = cols.findIndex((c) => c.spssVarName === 'Q5_rad1');
+    expect(row[rad1Col]).toBeNull();
+  });
+
+  it('레거시 문자열 응답(그룹 맵 아님) → null 안전 처리', () => {
+    const cols = generateSPSSColumns([grouped]);
+    const sub = makeSubmission({ q1: 'cellA' }); // 문자열은 그룹 응답 맵이 아님
+    const rows = buildDataRows(cols, [grouped], [sub]);
+    const row = rows[0];
+    if (row == null) throw new Error('row 없음');
+    const rad1Col = cols.findIndex((c) => c.spssVarName === 'Q5_rad1');
+    expect(row[rad1Col]).toBeNull();
+  });
+});

--- a/tests/unit/domains/spss/choice-group-export.test.ts
+++ b/tests/unit/domains/spss/choice-group-export.test.ts
@@ -78,6 +78,92 @@ describe('radio 옵션 그룹 export — generateSPSSColumns', () => {
     const cols = generateSPSSColumns([plain]);
     expect(cols.filter((c) => c.questionId === 'q2').map((c) => c.type)).toEqual(['single']);
   });
+
+});
+
+describe('radio 옵션 그룹 export — allowTextInput 사이드카 텍스트 변수', () => {
+  // allowTextInput 이 있는 셀을 포함하는 픽스처
+  const groupedWithText = {
+    id: 'q_txt',
+    type: 'radio',
+    title: 'TV 텍스트 질문',
+    required: false,
+    order: 1,
+    questionCode: 'QT',
+    choiceGroups: [
+      { id: 'g1', groupKey: 'rad1', type: 'radio', label: 'TV보유' },
+    ],
+    tableRowsData: [
+      {
+        id: 'r1',
+        label: '행1',
+        cells: [
+          { id: 'cellA', content: 'UHD', type: 'choice_opt', choiceGroupId: 'g1', spssNumericCode: 1, allowTextInput: true },
+          { id: 'cellB', content: 'FHD', type: 'choice_opt', choiceGroupId: 'g1', spssNumericCode: 2 },
+        ],
+      },
+    ],
+  } as unknown as Question;
+
+  it('allowTextInput 멤버 셀마다 option-text 사이드카 변수를 생성한다', () => {
+    const cols = generateSPSSColumns([groupedWithText]);
+    const names = cols.map((c) => c.spssVarName);
+    // 그룹 주변수
+    expect(names).toContain('QT_rad1');
+    // cellA 에 allowTextInput=true → 사이드카 변수
+    expect(names).toContain('QT_rad1_1_text');
+    // cellB 는 allowTextInput 없음 → 사이드카 없음
+    expect(names).not.toContain('QT_rad1_2_text');
+  });
+
+  it('사이드카 컬럼은 type=option-text 이고 optionId=cell.id 이다', () => {
+    const cols = generateSPSSColumns([groupedWithText]);
+    const sidecar = cols.find((c) => c.spssVarName === 'QT_rad1_1_text');
+    expect(sidecar?.type).toBe('option-text');
+    expect(sidecar?.optionId).toBe('cellA');
+  });
+
+  it('buildDataRows 에서 사이드카 옵션텍스트를 __optTexts__ 경로로 추출한다', () => {
+    const cols = generateSPSSColumns([groupedWithText]);
+    const sub = makeSubmission({
+      q_txt: { rad1: 'cellA' },
+      __optTexts__: { q_txt: { cellA: '직접입력' } },
+    });
+    const rows = buildDataRows(cols, [groupedWithText], [sub]);
+    const row = rows[0];
+    if (row == null) throw new Error('row 없음');
+    const sidecarIdx = cols.findIndex((c) => c.spssVarName === 'QT_rad1_1_text');
+    expect(row[sidecarIdx]).toBe('직접입력');
+  });
+
+  it('멤버 0인 phantom 그룹에 대한 choice-group 변수는 생성되지 않는다', () => {
+    // rad2 그룹은 선언됐지만 소속 셀이 없는 phantom
+    const withPhantom = {
+      ...grouped,
+      id: 'q_phantom',
+      questionCode: 'QP',
+      choiceGroups: [
+        { id: 'g1', groupKey: 'rad1', type: 'radio', label: 'TV보유' },
+        { id: 'g_phantom', groupKey: 'rad2', type: 'radio', label: '팬텀' },
+      ],
+      tableRowsData: [
+        {
+          id: 'r1',
+          label: '행1',
+          cells: [
+            // cellA/cellB 는 g1 소속, g_phantom 에는 아무 셀도 없음
+            { id: 'cellA', content: 'UHD', type: 'choice_opt', choiceGroupId: 'g1', spssNumericCode: 1 },
+            { id: 'cellB', content: 'FHD', type: 'choice_opt', choiceGroupId: 'g1', spssNumericCode: 2 },
+          ],
+        },
+      ],
+    } as unknown as Question;
+    const cols = generateSPSSColumns([withPhantom]);
+    const names = cols.filter((c) => c.questionId === 'q_phantom').map((c) => c.spssVarName);
+    // rad1 변수만 생성. rad2(phantom)는 없어야 한다.
+    expect(names).toContain('QP_rad1');
+    expect(names).not.toContain('QP_rad2');
+  });
 });
 
 describe('radio 옵션 그룹 export — buildDataRows 응답값 변환', () => {

--- a/tests/unit/domains/spss/value-labels-coverage.test.ts
+++ b/tests/unit/domains/spss/value-labels-coverage.test.ts
@@ -39,6 +39,25 @@ const checkboxManual = q({
   ],
 });
 
+const radioGrouped = q({
+  id: 'q4',
+  questionCode: 'Q4',
+  type: 'radio',
+  choiceGroups: [
+    { id: 'gg1', groupKey: 'rad1', type: 'radio', label: '그룹1' },
+  ],
+  tableRowsData: [
+    {
+      id: 'r1',
+      label: '행1',
+      cells: [
+        { id: 'cg1', content: '보기A', type: 'choice_opt', choiceGroupId: 'gg1', spssNumericCode: 1 },
+        { id: 'cg2', content: '보기B', type: 'choice_opt', choiceGroupId: 'gg1', spssNumericCode: 2 },
+      ],
+    },
+  ],
+});
+
 const tableWithCells = q({
   id: 'q3',
   questionCode: 'Q3',
@@ -80,11 +99,11 @@ const tableWithCells = q({
 });
 
 describe('categorical 변수 VALUE LABELS 전수 보장', () => {
-  const questions = [radioManual, checkboxManual, tableWithCells];
+  const questions = [radioManual, checkboxManual, tableWithCells, radioGrouped];
   const questionMap = new Map(questions.map((question) => [question.id, question]));
   const columns = generateSPSSColumns(questions);
 
-  const CATEGORICAL_TYPES = new Set(['single', 'checkbox-item', 'table-cell']);
+  const CATEGORICAL_TYPES = new Set(['single', 'checkbox-item', 'table-cell', 'choice-group']);
 
   it('categorical 컬럼은 전부 value labels를 가진다 — 0빈도 보기 포함', () => {
     const categorical = columns.filter(
@@ -112,5 +131,15 @@ describe('categorical 변수 VALUE LABELS 전수 보장', () => {
       const measure = resolveMeasure(col, questionMap.get(col.questionId));
       expect([VariableMeasure.Nominal, VariableMeasure.Ordinal]).toContain(measure);
     }
+  });
+
+  it('choice-group 변수는 buildValueLabels가 전 보기를 반환한다', () => {
+    const groupCol = columns.find((c) => c.type === 'choice-group' && c.questionId === 'q4');
+    expect(groupCol).toBeDefined();
+    const labels = buildValueLabels(groupCol!, radioGrouped);
+    expect(labels).toEqual([
+      { value: 1, label: '보기A' },
+      { value: 2, label: '보기B' },
+    ]);
   });
 });

--- a/tests/unit/domains/versioning/normalize-answers.test.ts
+++ b/tests/unit/domains/versioning/normalize-answers.test.ts
@@ -158,4 +158,20 @@ describe('normalizeToAnswers', () => {
     expect(answer!.objectValue).toEqual({ level1: 'seoul', level2: 'gangnam' });
     expect(answer!.questionType).toBe('multiselect');
   });
+
+  it('그룹별 선택 radio 응답(GroupedChoiceAnswer 맵)은 objectValue에 저장된다', () => {
+    // grouped radio 응답은 Record<groupKey, cellId> — 일반 object 이므로 objectValue 경로
+    const responses = {
+      'q-radio': { rad1: 'cellA', rad2: 'cellC' },
+    };
+
+    const answers = normalizeToAnswers(RESPONSE_ID, responses, mockQuestions);
+
+    const answer = answers.find((a) => a.questionId === 'q-radio');
+    expect(answer).toBeDefined();
+    expect(answer!.textValue).toBeNull();
+    expect(answer!.arrayValue).toBeNull();
+    expect(answer!.objectValue).toEqual({ rad1: 'cellA', rad2: 'cellC' });
+    expect(answer!.questionType).toBe('radio');
+  });
 });

--- a/tests/unit/features/builder/choice-opt-group-tab.test.tsx
+++ b/tests/unit/features/builder/choice-opt-group-tab.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { ChoiceGroup } from '@/types/survey';
+import { ChoiceOptCellTab } from '@/components/survey-builder/choice-opt-cell-tab';
+
+// 기본 공통 props (단일 radio 그룹 없는 초기 상태)
+function makeProps(overrides: Record<string, unknown> = {}) {
+  return {
+    choiceLabel: '',
+    onChoiceLabelChange: vi.fn(),
+    spssNumericCode: '' as const,
+    onSpssNumericCodeChange: vi.fn(),
+    allowTextInput: false,
+    onAllowTextInputChange: vi.fn(),
+    branchRule: undefined,
+    onBranchRuleChange: vi.fn(),
+    allQuestions: [],
+    currentQuestionId: 'q1',
+    choiceGroups: [] as ChoiceGroup[],
+    groupMemberCounts: {} as Record<string, number>,
+    choiceGroupId: '',
+    onChoiceGroupIdChange: vi.fn(),
+    onChoiceGroupsChange: vi.fn(),
+    ...overrides,
+  };
+}
+
+const rad1: ChoiceGroup = { id: 'g1', groupKey: 'rad1', type: 'radio', label: 'TV보유' };
+const rad2: ChoiceGroup = { id: 'g2', groupKey: 'rad2', type: 'radio', label: '구매의향' };
+
+describe('ChoiceOptCellTab — 옵션 그룹 지정 UI', () => {
+  it('그룹 목록에 멤버 수가 포함된 옵션이 표시된다', () => {
+    render(
+      <ChoiceOptCellTab
+        {...makeProps({
+          choiceGroups: [rad1, rad2],
+          groupMemberCounts: { g1: 2, g2: 3 },
+        })}
+      />,
+    );
+
+    // select 옵션에 그룹 라벨과 셀 수가 있어야 한다
+    expect(screen.getByRole('option', { name: /TV보유/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /셀 2/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /구매의향/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /셀 3/ })).toBeInTheDocument();
+  });
+
+  it('"+ 새 그룹" 선택 시 onChoiceGroupsChange와 onChoiceGroupIdChange가 새 그룹으로 호출된다', async () => {
+    const onChoiceGroupsChange = vi.fn();
+    const onChoiceGroupIdChange = vi.fn();
+
+    render(
+      <ChoiceOptCellTab
+        {...makeProps({
+          choiceGroups: [rad1, rad2],
+          groupMemberCounts: { g1: 2, g2: 3 },
+          onChoiceGroupsChange,
+          onChoiceGroupIdChange,
+        })}
+      />,
+    );
+
+    const select = screen.getByRole('combobox', { name: /그룹/ });
+    await userEvent.selectOptions(select, '__new__');
+
+    // 새 그룹이 choiceGroups 에 추가되어야 한다
+    expect(onChoiceGroupsChange).toHaveBeenCalledOnce();
+    const newGroups: ChoiceGroup[] = onChoiceGroupsChange.mock.calls[0]![0] as ChoiceGroup[];
+    expect(newGroups).toHaveLength(3);
+    const newGroup = newGroups[2]!;
+    expect(newGroup.groupKey).toBe('rad3');
+    expect(newGroup.type).toBe('radio');
+
+    // onChoiceGroupIdChange 는 새 그룹 id 로 호출되어야 한다
+    expect(onChoiceGroupIdChange).toHaveBeenCalledWith(newGroup.id);
+  });
+
+  it('소속 그룹의 라벨 수정 시 onChoiceGroupsChange가 해당 그룹 label만 바꾼 배열로 호출된다', async () => {
+    const onChoiceGroupsChange = vi.fn();
+
+    render(
+      <ChoiceOptCellTab
+        {...makeProps({
+          choiceGroups: [rad1, rad2],
+          groupMemberCounts: { g1: 2, g2: 3 },
+          choiceGroupId: 'g1',
+          onChoiceGroupsChange,
+        })}
+      />,
+    );
+
+    // 라벨 input 에 문자를 추가로 타이핑하면 onChange 가 호출되어야 한다.
+    // 컴포넌트가 controlled(value=currentGroup.label)이므로 type 이벤트 1개로 검증한다.
+    const labelInput = screen.getByPlaceholderText(/그룹 라벨/);
+    await userEvent.type(labelInput, 'X');
+
+    // 마지막 호출에서 g1 의 label 에 'X' 가 추가되어야 한다
+    const lastCall: ChoiceGroup[] =
+      onChoiceGroupsChange.mock.calls[onChoiceGroupsChange.mock.calls.length - 1]![0] as ChoiceGroup[];
+    const updated = lastCall.find((g) => g.id === 'g1')!;
+    expect(updated.label).toContain('X');
+    // g2 는 그대로
+    expect(lastCall.find((g) => g.id === 'g2')!.label).toBe('구매의향');
+  });
+
+  it('"(그룹 없음)" 선택 시 onChoiceGroupIdChange("")가 호출된다', async () => {
+    const onChoiceGroupIdChange = vi.fn();
+
+    render(
+      <ChoiceOptCellTab
+        {...makeProps({
+          choiceGroups: [rad1],
+          groupMemberCounts: { g1: 1 },
+          choiceGroupId: 'g1',
+          onChoiceGroupIdChange,
+        })}
+      />,
+    );
+
+    const select = screen.getByRole('combobox', { name: /그룹/ });
+    await userEvent.selectOptions(select, '');
+
+    expect(onChoiceGroupIdChange).toHaveBeenCalledWith('');
+  });
+
+  it('체크박스·순위 세그먼트 버튼은 disabled 상태다', () => {
+    render(<ChoiceOptCellTab {...makeProps()} />);
+
+    // 라디오는 활성, 나머지는 disabled
+    const checkboxBtn = screen.getByRole('button', { name: /체크박스/ });
+    const rankingBtn = screen.getByRole('button', { name: /순위/ });
+    expect(checkboxBtn).toBeDisabled();
+    expect(rankingBtn).toBeDisabled();
+  });
+});

--- a/tests/unit/serialize-cell.test.ts
+++ b/tests/unit/serialize-cell.test.ts
@@ -257,6 +257,20 @@ describe('buildUpdatedCell — 셀타입별 characterization', () => {
     expect(out.branchRule).toEqual({ ...branch, value: 'c1' });
   });
 
+  it('choice_opt: choiceGroupId 설정 시 저장되고 해제(빈 문자열) 시 키가 제거된다', () => {
+    const cellWithGroup: TableCell = { id: 'c1', type: 'choice_opt', content: '', choiceGroupId: 'g1' };
+
+    // 그룹 설정: choiceGroupId='g1'
+    const formSet: CellFormState = { ...baseForm('choice_opt'), choiceGroupId: 'g1' };
+    const outSet = buildUpdatedCell(formSet, baseCell);
+    expect(outSet.choiceGroupId).toBe('g1');
+
+    // 그룹 해제: choiceGroupId='' — 기존 셀에 choiceGroupId 가 있어도 키가 제거되어야 한다
+    const formRelease: CellFormState = { ...baseForm('choice_opt'), choiceGroupId: '' };
+    const outRelease = buildUpdatedCell(formRelease, cellWithGroup);
+    expect(outRelease).not.toHaveProperty('choiceGroupId');
+  });
+
   it('병합/정렬/textPosition/코드/라벨: 기본값은 키 제거, 비기본값만 저장', () => {
     const form: CellFormState = {
       ...baseForm('input'),

--- a/tests/unit/survey/choice-table-response-grouped.test.tsx
+++ b/tests/unit/survey/choice-table-response-grouped.test.tsx
@@ -159,3 +159,47 @@ describe('ChoiceTableResponse — 그룹별 선택 radio', () => {
     expect(inputC.checked).toBe(false);
   });
 });
+
+describe('비그룹 radio 계약 - 재클릭 해제 불가 유지', () => {
+  function plainRadioQuestion(): Question {
+    return {
+      id: 'qp',
+      type: 'radio',
+      title: '비그룹 라디오',
+      required: true,
+      order: 0,
+      tableColumns: [{ id: 'col1', label: '보기' }],
+      tableRowsData: [
+        {
+          id: 'row1',
+          label: '',
+          cells: [
+            { id: 'cellA', type: 'choice_opt', content: '', choiceLabel: '보기A' },
+            { id: 'cellB', type: 'choice_opt', content: '', choiceLabel: '보기B' },
+          ],
+        },
+      ],
+    } as unknown as Question;
+  }
+
+  it('선택된 셀을 다시 클릭해도 onChange가 호출되지 않는다', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse question={plainRadioQuestion()} value="cellA" onChange={onChange} />,
+    );
+    const checkedInput = document.querySelector('input[type="radio"]:checked');
+    expect(checkedInput).not.toBeNull();
+    fireEvent.click(checkedInput!);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('다른 셀 클릭은 기존대로 교체 선택된다', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse question={plainRadioQuestion()} value="cellA" onChange={onChange} />,
+    );
+    const inputs = document.querySelectorAll('input[type="radio"]');
+    fireEvent.click(inputs[1]!);
+    expect(onChange).toHaveBeenCalledWith('cellB');
+  });
+});

--- a/tests/unit/survey/choice-table-response-grouped.test.tsx
+++ b/tests/unit/survey/choice-table-response-grouped.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * 그룹별 선택 radio (choiceGroups) 렌더 동작 테스트
+ *
+ * 픽스처: rad1(cellA, cellB), rad2(cellC), 미소속(cellD)
+ * Step 1 — 실패 테스트 먼저 작성 (TDD Red 단계)
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Question } from '@/types/survey';
+import { ChoiceTableResponse } from '@/components/survey-response/choice-table-response';
+
+// 모바일 강제 — TablePreview(ResizeObserver 의존) 우회
+vi.mock('@/hooks/use-media-query', () => ({
+  useMobileView: () => true,
+  useMediaQuery: () => true,
+}));
+
+/**
+ * 그룹별 선택 radio 질문 픽스처.
+ * - rad1: cellA, cellB
+ * - rad2: cellC
+ * - 미소속(default): cellD
+ */
+function groupedRadioQuestion(): Question {
+  return {
+    id: 'qg',
+    type: 'radio',
+    title: '그룹 라디오',
+    required: true,
+    order: 0,
+    tableColumns: [
+      { id: 'col1', label: '그룹1' },
+      { id: 'col2', label: '그룹2' },
+      { id: 'col3', label: '미소속' },
+    ],
+    tableRowsData: [
+      {
+        id: 'row1',
+        label: '',
+        cells: [
+          {
+            id: 'cellA',
+            type: 'choice_opt',
+            content: '',
+            choiceLabel: '보기A',
+            choiceGroupId: 'grp1',
+          },
+          {
+            id: 'cellB',
+            type: 'choice_opt',
+            content: '',
+            choiceLabel: '보기B',
+            choiceGroupId: 'grp1',
+          },
+          {
+            id: 'cellC',
+            type: 'choice_opt',
+            content: '',
+            choiceLabel: '보기C',
+            choiceGroupId: 'grp2',
+          },
+          {
+            id: 'cellD',
+            type: 'choice_opt',
+            content: '',
+            choiceLabel: '보기D',
+            // choiceGroupId 없음 — 미소속
+          },
+        ],
+      },
+    ],
+    choiceGroups: [
+      { id: 'grp1', type: 'radio', groupKey: 'rad1', label: '그룹1' },
+      { id: 'grp2', type: 'radio', groupKey: 'rad2', label: '그룹2' },
+    ],
+  } as unknown as Question;
+}
+
+describe('ChoiceTableResponse — 그룹별 선택 radio', () => {
+  it('1. 그룹마다 독립 선택: cellA 클릭 시 onChange({ rad1: cellA })', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse
+        question={groupedRadioQuestion()}
+        value={null}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('보기A'));
+    expect(onChange).toHaveBeenCalledWith({ rad1: 'cellA' });
+  });
+
+  it('1b. 기존 선택이 있는 상태에서 다른 그룹 클릭 시 두 그룹 모두 유지', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse
+        question={groupedRadioQuestion()}
+        value={{ rad1: 'cellA' }}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('보기C'));
+    expect(onChange).toHaveBeenCalledWith({ rad1: 'cellA', rad2: 'cellC' });
+  });
+
+  it('2. 같은 그룹 내 교체: rad1에서 cellA→cellB', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse
+        question={groupedRadioQuestion()}
+        value={{ rad1: 'cellA' }}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('보기B'));
+    expect(onChange).toHaveBeenCalledWith({ rad1: 'cellB' });
+  });
+
+  it('3. 재클릭 해제(토글): cellA 선택 상태에서 cellA 클릭 시 {} (rad1 키 삭제)', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse
+        question={groupedRadioQuestion()}
+        value={{ rad1: 'cellA' }}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('보기A'));
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+
+  it('4. 미소속 셀(cellD) 클릭 시 default 키에 저장', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse
+        question={groupedRadioQuestion()}
+        value={null}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('보기D'));
+    expect(onChange).toHaveBeenCalledWith({ default: 'cellD' });
+  });
+
+  it('5. 선택 상태 표시: value={ rad1: cellA }이면 cellA만 checked', () => {
+    render(
+      <ChoiceTableResponse
+        question={groupedRadioQuestion()}
+        value={{ rad1: 'cellA' }}
+        onChange={vi.fn()}
+      />,
+    );
+    const inputA = screen.getByLabelText('보기A') as HTMLInputElement;
+    const inputB = screen.getByLabelText('보기B') as HTMLInputElement;
+    const inputC = screen.getByLabelText('보기C') as HTMLInputElement;
+    expect(inputA.checked).toBe(true);
+    expect(inputB.checked).toBe(false);
+    expect(inputC.checked).toBe(false);
+  });
+});

--- a/tests/unit/utils/choice-group-helpers.test.ts
+++ b/tests/unit/utils/choice-group-helpers.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_GROUP_KEY,
+  collectRadioGroups,
+  getGroupKeyOfCell,
+  isGroupedChoiceQuestion,
+  nextGroupKey,
+  pruneChoiceGroups,
+} from '@/utils/choice-group-helpers';
+import type { ChoiceGroup, Question } from '@/types/survey';
+
+const rad1: ChoiceGroup = { id: 'g1', groupKey: 'rad1', type: 'radio', label: 'TV보유' };
+const rad2: ChoiceGroup = { id: 'g2', groupKey: 'rad2', type: 'radio', label: '구매의향' };
+
+function makeQuestion(overrides: Record<string, unknown>): Question {
+  return {
+    id: 'q1', type: 'radio', title: '질문', required: false, order: 1,
+    ...overrides,
+  } as unknown as Question;
+}
+
+const grouped = makeQuestion({
+  choiceGroups: [rad1, rad2],
+  tableRowsData: [
+    {
+      id: 'r1', label: '행1',
+      cells: [
+        { id: 'cellA', content: 'UHD', type: 'choice_opt', choiceGroupId: 'g1' },
+        { id: 'cellB', content: 'FHD', type: 'choice_opt', choiceGroupId: 'g1' },
+        { id: 'cellC', content: '있음', type: 'choice_opt', choiceGroupId: 'g2' },
+        { id: 'cellD', content: '미소속', type: 'choice_opt' },
+        { id: 'cellX', content: '텍스트', type: 'text' },
+      ],
+    },
+  ],
+});
+
+describe('isGroupedChoiceQuestion', () => {
+  it('radio 그룹이 있으면 true', () => {
+    expect(isGroupedChoiceQuestion(grouped)).toBe(true);
+  });
+
+  it('choiceGroups가 없거나 비면 false - 하위호환 분기점', () => {
+    expect(isGroupedChoiceQuestion(makeQuestion({}))).toBe(false);
+    expect(isGroupedChoiceQuestion(makeQuestion({ choiceGroups: [] }))).toBe(false);
+  });
+});
+
+describe('getGroupKeyOfCell', () => {
+  it('셀의 choiceGroupId를 groupKey로 해석한다', () => {
+    expect(getGroupKeyOfCell(grouped, 'cellA')).toBe('rad1');
+    expect(getGroupKeyOfCell(grouped, 'cellC')).toBe('rad2');
+  });
+
+  it('미소속 셀은 default 키', () => {
+    expect(getGroupKeyOfCell(grouped, 'cellD')).toBe(DEFAULT_GROUP_KEY);
+  });
+
+  it('존재하지 않는 그룹 id를 참조하는 셀도 default로 폴백한다', () => {
+    const broken = makeQuestion({
+      choiceGroups: [rad1],
+      tableRowsData: [{ id: 'r1', label: '행1', cells: [
+        { id: 'cellZ', content: '', type: 'choice_opt', choiceGroupId: 'ghost' },
+      ] }],
+    });
+    expect(getGroupKeyOfCell(broken, 'cellZ')).toBe(DEFAULT_GROUP_KEY);
+  });
+});
+
+describe('collectRadioGroups', () => {
+  it('명시 그룹 + 미소속 셀 존재 시 default를 멤버 셀과 함께 반환한다', () => {
+    const groups = collectRadioGroups(grouped);
+    expect(groups.map((g) => g.groupKey)).toEqual(['rad1', 'rad2', DEFAULT_GROUP_KEY]);
+    expect(groups[0]!.cells.map((c) => c.id)).toEqual(['cellA', 'cellB']);
+    expect(groups[2]!.cells.map((c) => c.id)).toEqual(['cellD']);
+  });
+
+  it('미소속 셀이 없으면 default 그룹을 만들지 않는다', () => {
+    const noDefault = makeQuestion({
+      choiceGroups: [rad1],
+      tableRowsData: [{ id: 'r1', label: '행1', cells: [
+        { id: 'cellA', content: 'UHD', type: 'choice_opt', choiceGroupId: 'g1' },
+      ] }],
+    });
+    expect(collectRadioGroups(noDefault).map((g) => g.groupKey)).toEqual(['rad1']);
+  });
+});
+
+describe('nextGroupKey', () => {
+  it('기존 rad 순번 다음 번호를 발번한다', () => {
+    expect(nextGroupKey([rad1, rad2], 'radio')).toBe('rad3');
+  });
+
+  it('그룹이 없으면 rad1', () => {
+    expect(nextGroupKey([], 'radio')).toBe('rad1');
+  });
+
+  it('수동 오버라이드로 구멍이 나도 최대+1', () => {
+    const custom: ChoiceGroup = { id: 'g9', groupKey: 'rad9', type: 'radio', label: 'x' };
+    expect(nextGroupKey([custom], 'radio')).toBe('rad10');
+  });
+});
+
+describe('pruneChoiceGroups', () => {
+  it('멤버 0 그룹을 제거한다', () => {
+    const q = makeQuestion({
+      choiceGroups: [rad1, rad2],
+      tableRowsData: [{ id: 'r1', label: '행1', cells: [
+        { id: 'cellA', content: '', type: 'choice_opt', choiceGroupId: 'g1' },
+      ] }],
+    });
+    expect(pruneChoiceGroups(q)?.map((g) => g.groupKey)).toEqual(['rad1']);
+  });
+
+  it('전부 멤버가 있으면 동일 참조 반환', () => {
+    expect(pruneChoiceGroups(grouped)).toBe(grouped.choiceGroups);
+  });
+
+  it('choiceGroups가 없으면 undefined', () => {
+    expect(pruneChoiceGroups(makeQuestion({}))).toBeUndefined();
+  });
+});

--- a/tests/unit/utils/choice-group-helpers.test.ts
+++ b/tests/unit/utils/choice-group-helpers.test.ts
@@ -85,6 +85,29 @@ describe('collectRadioGroups', () => {
     });
     expect(collectRadioGroups(noDefault).map((g) => g.groupKey)).toEqual(['rad1']);
   });
+
+  it('멤버 0인 명시 그룹은 collectRadioGroups 에서 제외된다', () => {
+    // rad1 은 멤버 있음, rad2 는 멤버 없음(phantom)
+    const withPhantom = makeQuestion({
+      choiceGroups: [rad1, rad2],
+      tableRowsData: [{ id: 'r1', label: '행1', cells: [
+        { id: 'cellA', content: 'UHD', type: 'choice_opt', choiceGroupId: 'g1' },
+        { id: 'cellD', content: '미소속', type: 'choice_opt' },
+      ] }],
+    });
+    const groups = collectRadioGroups(withPhantom);
+    // rad2(g2)는 멤버 0이므로 제외. rad1 + default(미소속 셀) 만 반환.
+    expect(groups.map((g) => g.groupKey)).toEqual(['rad1', DEFAULT_GROUP_KEY]);
+  });
+
+  it('멤버 0인 명시 그룹만 있을 때 미소속 셀이 없으면 빈 배열', () => {
+    // 모든 그룹이 phantom 이고 미소속 셀도 없는 극단 케이스
+    const allPhantom = makeQuestion({
+      choiceGroups: [rad1, rad2],
+      tableRowsData: [{ id: 'r1', label: '행1', cells: [] }],
+    });
+    expect(collectRadioGroups(allPhantom)).toEqual([]);
+  });
 });
 
 describe('nextGroupKey', () => {


### PR DESCRIPTION
## Summary
- Case A radio 질문(테이블 내장 보기 셀)에 **옵션 그룹** 도입 — 보기 옵션 탭에서 셀을 그룹(rad1, rad2...)에 귀속시키면 응답자는 그룹마다 하나씩 선택(같은 그룹 교체, 재클릭 해제), export는 그룹별 1변수(`질문코드_groupKey`) 생성
- 그룹 정보는 `Question.choiceGroups` registry 한 곳, 셀은 `choiceGroupId` 참조만 — 라벨 수정 1곳 반영, 멤버 0 그룹은 저장 시 자동 prune(삭제 UI 없음)
- 하위호환: 그룹 미지정 질문/셀은 기존 동작·변수명(`질문코드`) 불변. 미소속 셀은 `default` 그룹으로 기존 변수명 유지
- 리뷰 사이클 수정 5건 포함: phantom 그룹 DB 잔류, 행/열 삭제발 phantom의 required 응답 영구 차단(Critical), 비그룹 radio 동작 보존, 그룹+텍스트입력 export 사이드카 누락, 미영속 질문 첫 그룹 유실
- DESIGN.md 블루 명세를 기존 버튼 관행(#3b82f6 blue-500 계열)으로 정렬

## Test Plan
- [x] 전체 스위트 1332/1332 통과, lint 0 errors, tsc 0 (scripts/ 제외)
- [x] 신규 테스트: 그룹 헬퍼 13 + 빌더 탭 5 + grouped 응답 렌더/검증/분기 ~20 + export 12
- [ ] 수동: 빌더에서 rad1/rad2 지정 → 저장·재로드 유지
- [ ] 수동: publish 후 응답 페이지 — 그룹마다 선택·교체·재클릭 해제
- [ ] 수동: .sav export — `Q코드_rad1`/`Q코드_rad2` 변수 + 값 라벨

🤖 Generated with [Claude Code](https://claude.com/claude-code)