### PR TITLE
feat: checkbox 옵션 그룹 - 그룹 내 복수 선택 + counted 변수 + MCGROUP

### DIFF
--- a/src/components/survey-builder/choice-opt-cell-tab.tsx
+++ b/src/components/survey-builder/choice-opt-cell-tab.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
@@ -54,17 +56,34 @@ export function ChoiceOptCellTab({
   onChoiceGroupIdChange,
   onChoiceGroupsChange,
 }: ChoiceOptCellTabProps) {
-  const radioGroups = choiceGroups.filter((g) => g.type === 'radio');
-  const nextKey = nextGroupKey(radioGroups, 'radio');
-  const currentGroup = radioGroups.find((g) => g.id === choiceGroupId);
+  // 현재 셀이 소속된 그룹의 type을 초기값으로 사용하고, 미소속이면 '라디오' 기본값
+  const currentGroupType =
+    choiceGroups.find((g) => g.id === choiceGroupId)?.type ?? 'radio';
+  // ranking 그룹에 소속된 경우도 '라디오'로 폴백 (세그먼트에 ranking 없음)
+  const initialSelectedType: 'radio' | 'checkbox' =
+    currentGroupType === 'checkbox' ? 'checkbox' : 'radio';
+
+  const [selectedType, setSelectedType] = useState<'radio' | 'checkbox'>(initialSelectedType);
+
+  // 선택된 종류의 그룹만 드롭다운에 표시
+  const filteredGroups = choiceGroups.filter((g) => g.type === selectedType);
+  const nextKey = nextGroupKey(filteredGroups, selectedType);
+  const currentGroup = filteredGroups.find((g) => g.id === choiceGroupId);
+
+  function handleTypeSelect(type: 'radio' | 'checkbox') {
+    if (type === selectedType) return;
+    setSelectedType(type);
+    // 다른 type 그룹에 남지 않도록 소속 해제
+    onChoiceGroupIdChange('');
+  }
 
   function handleGroupSelectChange(value: string) {
     if (value === '__new__') {
-      const key = nextGroupKey(choiceGroups, 'radio');
+      const key = nextGroupKey(choiceGroups, selectedType);
       const newGroup: ChoiceGroup = {
         id: generateId(),
         groupKey: key,
-        type: 'radio',
+        type: selectedType,
         label: '',
       };
       onChoiceGroupsChange([...choiceGroups, newGroup]);
@@ -83,22 +102,31 @@ export function ChoiceOptCellTab({
 
   return (
     <div className="space-y-4">
-      {/* 옵션 종류 세그먼트 — 라디오만 활성 */}
+      {/* 옵션 종류 세그먼트 — 라디오·체크박스 활성, 순위 disabled */}
       <div className="space-y-1.5">
         <Label className="text-sm font-medium">옵션 종류</Label>
         <div className="flex gap-1">
           <button
             type="button"
-            aria-pressed="true"
-            className="rounded-md bg-blue-500 px-3 py-1.5 text-xs font-medium text-white"
+            aria-pressed={selectedType === 'radio'}
+            onClick={() => handleTypeSelect('radio')}
+            className={
+              selectedType === 'radio'
+                ? 'rounded-md bg-blue-500 px-3 py-1.5 text-xs font-medium text-white'
+                : 'rounded-md bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-200'
+            }
           >
             라디오
           </button>
           <button
             type="button"
-            disabled
-            title="추후 지원"
-            className="cursor-not-allowed rounded-md bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-400"
+            aria-pressed={selectedType === 'checkbox'}
+            onClick={() => handleTypeSelect('checkbox')}
+            className={
+              selectedType === 'checkbox'
+                ? 'rounded-md bg-blue-500 px-3 py-1.5 text-xs font-medium text-white'
+                : 'rounded-md bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-200'
+            }
           >
             체크박스
           </button>
@@ -127,7 +155,7 @@ export function ChoiceOptCellTab({
             className="flex-1 rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
             <option value="">(그룹 없음)</option>
-            {radioGroups.map((g) => (
+            {filteredGroups.map((g) => (
               <option key={g.id} value={g.id}>
                 {g.groupKey}
                 {g.label ? ` — ${g.label}` : ''}
@@ -147,7 +175,9 @@ export function ChoiceOptCellTab({
           />
         </div>
         <p className="text-xs text-gray-500">
-          같은 그룹의 셀들 중 하나만 선택됩니다. 그룹 라벨 수정은 그룹 전체에 반영됩니다.
+          {selectedType === 'checkbox'
+            ? '같은 그룹에서 여러 개를 선택할 수 있습니다. 그룹 라벨 수정은 그룹 전체에 반영됩니다.'
+            : '같은 그룹의 셀들 중 하나만 선택됩니다. 그룹 라벨 수정은 그룹 전체에 반영됩니다.'}
         </p>
       </div>
 

--- a/src/components/survey-response/choice-table-response.tsx
+++ b/src/components/survey-response/choice-table-response.tsx
@@ -51,7 +51,11 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
     if (isCheckbox) return Array.isArray(value) ? (value as string[]) : [];
     if (isGrouped) {
       if (!value || typeof value !== 'object' || Array.isArray(value)) return [];
-      return Object.values(value as GroupedChoiceAnswer).filter(Boolean);
+      // GroupedChoiceAnswer 값은 string | string[] — isGrouped 분기는 현재 radio 그룹
+      // 전제(string)이므로 string인 값만 추출한다. Task 4에서 checkbox 그룹 지원 시 확장.
+      return Object.values(value as GroupedChoiceAnswer).filter(
+        (v): v is string => typeof v === 'string' && v !== '',
+      );
     }
     return typeof value === 'string' && value ? [value] : [];
   }, [isCheckbox, isGrouped, value]);

--- a/src/components/survey-response/choice-table-response.tsx
+++ b/src/components/survey-response/choice-table-response.tsx
@@ -11,6 +11,7 @@ import { resolveChoiceOptions } from '@/utils/choice-source';
 import {
   isGroupedChoiceQuestion,
   getGroupKeyOfCell,
+  getGroupTypeOfCell,
   type GroupedChoiceAnswer,
 } from '@/utils/choice-group-helpers';
 import { findMobileHeaderCell } from '@/utils/mobile-display-cells';
@@ -36,8 +37,9 @@ interface ChoiceTableResponseProps {
  */
 export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableResponseProps) {
   const isCheckbox = question.type === 'checkbox';
-  // 그룹별 선택 모드 여부 — radio + choiceGroups 1개 이상 정의된 경우만 true
-  const isGrouped = !isCheckbox && isGroupedChoiceQuestion(question);
+  // 그룹별 선택 모드 여부 — radio 또는 checkbox 그룹이 1개 이상 정의된 경우 true.
+  // isCheckbox 가드를 제거하여 checkbox 질문도 grouped 경로를 밟을 수 있게 한다.
+  const isGrouped = isGroupedChoiceQuestion(question);
   const isMobile = useMobileView();
   const attrs = useContactAttrs();
   const options = useMemo(() => resolveChoiceOptions(question), [question]);
@@ -46,16 +48,19 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
     [options],
   );
 
-  // checkbox: cell.id[] / 비그룹 radio: [선택 cellId] / 그룹별 radio: 맵에서 values 추출
+  // checkbox: cell.id[] / 비그룹 radio: [선택 cellId] / 그룹별(radio+checkbox 혼재): 맵 values flat
   const selectedIds: string[] = useMemo(() => {
-    if (isCheckbox) return Array.isArray(value) ? (value as string[]) : [];
+    if (!isGrouped && isCheckbox) return Array.isArray(value) ? (value as string[]) : [];
     if (isGrouped) {
       if (!value || typeof value !== 'object' || Array.isArray(value)) return [];
-      // GroupedChoiceAnswer 값은 string | string[] — isGrouped 분기는 현재 radio 그룹
-      // 전제(string)이므로 string인 값만 추출한다. Task 4에서 checkbox 그룹 지원 시 확장.
-      return Object.values(value as GroupedChoiceAnswer).filter(
-        (v): v is string => typeof v === 'string' && v !== '',
-      );
+      // GroupedChoiceAnswer 값은 string(radio 그룹) | string[](checkbox 그룹).
+      // flat()으로 두 종류를 통합하여 선택된 모든 cellId 를 추출한다.
+      return Object.values(value as GroupedChoiceAnswer)
+        .flatMap((v): string[] => {
+          if (typeof v === 'string' && v !== '') return [v];
+          if (Array.isArray(v)) return v.filter((s): s is string => typeof s === 'string');
+          return [];
+        });
     }
     return typeof value === 'string' && value ? [value] : [];
   }, [isCheckbox, isGrouped, value]);
@@ -67,11 +72,33 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
 
   const toggle = (cellId: string, checked: boolean) => {
     if (isGrouped) {
-      // 그룹별 선택: 같은 그룹 내에서 교체, 재클릭 시 해제(키 삭제)
       const groupKey = getGroupKeyOfCell(question, cellId);
+      const cellType = getGroupTypeOfCell(question, cellId);
       const map = (value && typeof value === 'object' && !Array.isArray(value)
         ? (value as GroupedChoiceAnswer)
         : {}) as GroupedChoiceAnswer;
+
+      if (cellType === 'checkbox') {
+        // checkbox 그룹: 배열 push/filter. 빈 배열이 되면 키 삭제.
+        const arr = Array.isArray(map[groupKey]) ? (map[groupKey] as string[]) : [];
+        let next: string[];
+        if (arr.includes(cellId)) {
+          // 체크 해제
+          next = arr.filter((id) => id !== cellId);
+        } else {
+          // 체크 추가
+          next = [...arr, cellId];
+        }
+        if (next.length === 0) {
+          const { [groupKey]: _removed, ...rest } = map;
+          onChange(rest as GroupedChoiceAnswer);
+        } else {
+          onChange({ ...map, [groupKey]: next });
+        }
+        return;
+      }
+
+      // radio 그룹: 같은 그룹 내에서 교체, 재클릭 시 해제(키 삭제)
       if (map[groupKey] === cellId) {
         // 재클릭 해제 — 해당 키 삭제
         const { [groupKey]: _removed, ...rest } = map;
@@ -96,12 +123,25 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
   };
 
   const getChoiceCellState = (cell: TableCell) => {
-    const checked = isGrouped
-      ? // 그룹별 선택: 그룹 키의 현재 선택값이 이 셀인지 확인
-        (value && typeof value === 'object' && !Array.isArray(value)
-          ? (value as GroupedChoiceAnswer)[getGroupKeyOfCell(question, cell.id)] === cell.id
-          : false)
-      : selectedIds.includes(cell.id);
+    let checked: boolean;
+    if (isGrouped) {
+      const map =
+        value && typeof value === 'object' && !Array.isArray(value)
+          ? (value as GroupedChoiceAnswer)
+          : {};
+      const groupKey = getGroupKeyOfCell(question, cell.id);
+      const cellType = getGroupTypeOfCell(question, cell.id);
+      if (cellType === 'checkbox') {
+        // checkbox 그룹: 맵 값이 배열이고 그 배열에 cellId 가 포함되어야 checked
+        const arr = map[groupKey];
+        checked = Array.isArray(arr) && arr.includes(cell.id);
+      } else {
+        // radio 그룹: 맵 값이 이 cellId 와 일치하면 checked
+        checked = map[groupKey] === cell.id;
+      }
+    } else {
+      checked = selectedIds.includes(cell.id);
+    }
     return {
       checked,
       disabled: isMaxSelectionReached && !checked,
@@ -112,23 +152,32 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
   const renderCell = (cell: TableCell): ReactNode => {
     if (cell.type !== 'choice_opt' || cell.isHidden) return undefined;
     const { checked, disabled, option } = getChoiceCellState(cell);
-    // 그룹별 선택 모드: radio name 을 그룹 키 단위로 분리해야 브라우저가 그룹 간 선택을 지우지 않는다.
+    // 그룹별 선택 모드: name 을 그룹 키 단위로 분리해야 브라우저가 그룹 간 선택을 지우지 않는다.
+    // checkbox 그룹은 name 이 동작에 영향 없지만 일관성을 위해 동일 패턴을 유지한다.
     const inputName = isGrouped
       ? `${question.id}-${getGroupKeyOfCell(question, cell.id)}`
       : question.id;
 
+    // 셀이 속한 그룹의 type 결정. 비그룹 경로는 질문 type 그대로 사용.
+    const cellType = isGrouped ? getGroupTypeOfCell(question, cell.id) : (isCheckbox ? 'checkbox' : 'radio');
+
     return (
       <div className="flex flex-col items-center gap-2">
         <input
-          type={isCheckbox ? 'checkbox' : 'radio'}
+          type={cellType === 'checkbox' ? 'checkbox' : 'radio'}
           name={inputName}
           aria-label={option?.label ?? '선택'}
           checked={checked}
           disabled={disabled}
-          // 그룹 모드 radio 재클릭(이미 선택된 셀) 은 onChange 가 발화하지 않으므로
-          // onClick 에서 토글 해제 처리. 비그룹 radio 는 기존대로 해제 불가(onChange만).
-          onClick={isGrouped ? () => toggle(cell.id, !checked) : undefined}
-          onChange={!isGrouped || isCheckbox ? (e) => toggle(cell.id, e.target.checked) : undefined}
+          // radio 셀: 그룹 모드에서 재클릭(이미 선택) 은 onChange 가 발화하지 않으므로
+          //   onClick 에서 토글 해제. 비그룹 radio 는 기존대로 해제 불가(onChange만).
+          // checkbox 셀: onChange 경로(native toggle). onClick 불필요.
+          onClick={isGrouped && cellType === 'radio' ? () => toggle(cell.id, !checked) : undefined}
+          onChange={
+            !isGrouped || cellType === 'checkbox'
+              ? (e) => toggle(cell.id, e.target.checked)
+              : undefined
+          }
           className="h-4 w-4"
         />
         {option?.allowTextInput && checked && (
@@ -168,10 +217,14 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
               const cardLabel = headerText
                 ? substituteTokens(headerText, attrs)
                 : (option?.label ?? '(라벨 없음)');
-              // 그룹별 선택 모드: radio name 을 그룹 키 단위로 분리
+              // 그룹별 선택 모드: name 을 그룹 키 단위로 분리
               const mobileInputName = isGrouped
                 ? `${question.id}-${getGroupKeyOfCell(question, choiceCell.id)}`
                 : question.id;
+              // 모바일도 셀별 group type 결정
+              const mobileCellType = isGrouped
+                ? getGroupTypeOfCell(question, choiceCell.id)
+                : (isCheckbox ? 'checkbox' : 'radio');
               return (
                 <MobileOptionCard
                   key={choiceCell.id}
@@ -182,14 +235,18 @@ export function ChoiceTableResponse({ question, value, onChange }: ChoiceTableRe
                   onToggle={() => toggle(choiceCell.id, !checked)}
                   control={
                     <input
-                      type={isCheckbox ? 'checkbox' : 'radio'}
+                      type={mobileCellType === 'checkbox' ? 'checkbox' : 'radio'}
                       name={mobileInputName}
                       aria-label={cardLabel}
                       checked={checked}
                       disabled={disabled}
-                      // 그룹 모드 radio 만 onClick 토글 해제. 비그룹은 기존 onChange 경로 유지.
-                      onClick={isGrouped ? () => toggle(choiceCell.id, !checked) : undefined}
-                      onChange={!isGrouped || isCheckbox ? (e) => toggle(choiceCell.id, e.target.checked) : undefined}
+                      // radio 셀: 그룹 모드에서 재클릭 onClick 해제. checkbox 셀: onChange 경로.
+                      onClick={isGrouped && mobileCellType === 'radio' ? () => toggle(choiceCell.id, !checked) : undefined}
+                      onChange={
+                        !isGrouped || mobileCellType === 'checkbox'
+                          ? (e) => toggle(choiceCell.id, e.target.checked)
+                          : undefined
+                      }
                       className="h-5 w-5"
                     />
                   }

--- a/src/lib/analytics/raw-export-helpers.ts
+++ b/src/lib/analytics/raw-export-helpers.ts
@@ -77,6 +77,13 @@ export function buildCodebookValueLabel(
       }
       return '';
 
+    case 'choice-group-item': {
+      // checkbox-item 형식 재사용: 빈값=비선택, {code}=선택
+      const code = col.choiceGroupMemberCode;
+      if (code == null) return '';
+      return `빈값=비선택, ${code}=선택`;
+    }
+
     case 'ranking-rank':
     case 'table-cell-ranking': {
       const opts = col.cellOptions ?? (q ? resolveRankingOptions(q) : []);

--- a/src/lib/analytics/raw-workbook.ts
+++ b/src/lib/analytics/raw-workbook.ts
@@ -196,6 +196,8 @@ export function row2Label(c: SPSSExportColumn): string {
   if (c.cellExportLabel) return c.cellExportLabel;
   if (
     c.type === 'checkbox-item' ||
+    c.type === 'choice-group' ||
+    c.type === 'choice-group-item' ||
     c.type === 'ranking-rank' ||
     c.type === 'ranking-other' ||
     c.type === 'option-text' ||

--- a/src/lib/analytics/spss-excel-export.ts
+++ b/src/lib/analytics/spss-excel-export.ts
@@ -34,7 +34,7 @@ import {
   resolveRankVarName,
 } from '@/utils/table-cell-code-generator';
 import {
-  collectRadioGroups,
+  collectChoiceGroups,
   DEFAULT_GROUP_KEY,
   isGroupedChoiceQuestion,
 } from '@/utils/choice-group-helpers';
@@ -172,7 +172,9 @@ export function generateSPSSColumns(questions: Question[]): SPSSExportColumn[] {
       }
     } else if (q.type === 'radio' && isGroupedChoiceQuestion(q)) {
       // choiceGroups 기반 radio — 그룹별 변수 1개씩 생성
-      for (const group of collectRadioGroups(q)) {
+      for (const group of collectChoiceGroups(q)) {
+        // checkbox 그룹은 Task 4에서 정식 구현 예정. 현재는 skip하여 radio 전제 로직 보호.
+        if (group.type !== 'radio') continue;
         const cellValueMap: Record<string, number> = {};
         const valueLabels: Array<{ value: number; label: string }> = [];
         group.cells.forEach((cell, idx) => {

--- a/src/lib/analytics/spss-excel-export.ts
+++ b/src/lib/analytics/spss-excel-export.ts
@@ -60,7 +60,8 @@ export interface SPSSExportColumn {
     | 'table-cell-ranking-other'
     | 'option-text'
     | 'table-cell-option-text'
-    | 'choice-group';
+    | 'choice-group'
+    | 'choice-group-item';
   optionIndex?: number;
   optionValue?: string;
   tableCellId?: string;
@@ -95,6 +96,13 @@ export interface SPSSExportColumn {
   choiceGroupCellValueMap?: Record<string, number>;
   // 숫자값 → SPSS VALUE LABEL 배열
   choiceGroupValueLabels?: Array<{ value: number; label: string }>;
+  // === 'choice-group-item' 전용: checkbox choiceGroups 기반 보기별 counted 변수 ===
+  // 이 변수가 담당하는 보기가 속한 그룹의 groupKey
+  // (choice-group 과 공용: choiceGroupKey)
+  // 이 변수가 담당하는 보기의 셀 id
+  choiceGroupMemberCellId?: string;
+  // 이 보기 선택 시 저장할 counted 숫자값 (spssNumericCode 또는 그룹 내 1-based 폴백)
+  choiceGroupMemberCode?: number;
 }
 
 /**
@@ -129,7 +137,95 @@ export function generateSPSSColumns(questions: Question[]): SPSSExportColumn[] {
     }
     if (!q.questionCode) continue;
 
-    if (q.type === 'checkbox') {
+    if ((q.type === 'radio' || q.type === 'checkbox') && isGroupedChoiceQuestion(q)) {
+      // choiceGroups 가 1개 이상 정의된 radio/checkbox 질문은 이 분기에서 처리.
+      // 그룹 없는 checkbox 질문은 아래 else-if 의 기존 checkbox-item 경로를 탄다.
+      // choiceGroups 기반 radio/checkbox — 그룹별 변수 생성
+      for (const group of collectChoiceGroups(q)) {
+        if (group.type === 'radio') {
+          // radio 그룹 → 기존 'choice-group' 1변수 (무변경)
+          const cellValueMap: Record<string, number> = {};
+          const valueLabels: Array<{ value: number; label: string }> = [];
+          group.cells.forEach((cell, idx) => {
+            const code = cell.spssNumericCode ?? idx + 1;
+            cellValueMap[cell.id] = code;
+            valueLabels.push({
+              value: code,
+              label: (cell.choiceLabel ?? '').trim() || (cell.content ?? '').trim() || '(라벨 없음)',
+            });
+          });
+          const isDefault = group.groupKey === DEFAULT_GROUP_KEY;
+          const groupVarName = isDefault ? q.questionCode : `${q.questionCode}_${group.groupKey}`;
+          columns.push({
+            spssVarName: groupVarName,
+            questionText: q.title,
+            optionLabel: group.label || q.title,
+            questionId: q.id,
+            type: 'choice-group',
+            choiceGroupKey: group.groupKey,
+            choiceGroupCellValueMap: cellValueMap,
+            choiceGroupValueLabels: valueLabels,
+          });
+          // allowTextInput 멤버 셀마다 STRING 사이드카 텍스트 변수 생성.
+          // 저장 경로는 __optTexts__[questionId][cell.id] 로 비그룹과 동일하므로
+          // optionId=cell.id 를 그대로 사용해 기존 option-text 추출 case 가 동작한다.
+          group.cells.forEach((cell, idx) => {
+            if (!cell.allowTextInput) return;
+            const varNumber = cell.spssNumericCode != null ? String(cell.spssNumericCode) : String(idx + 1);
+            columns.push({
+              spssVarName: buildOptionTextVarName(groupVarName, varNumber),
+              questionText: q.title,
+              optionLabel: `${(cell.choiceLabel ?? '').trim() || (cell.content ?? '').trim() || '(라벨 없음)'} (텍스트)`,
+              questionId: q.id,
+              type: 'option-text',
+              optionId: cell.id,
+            });
+          });
+        } else {
+          // checkbox 그룹 → 멤버 셀별 'choice-group-item' (counted value 방식)
+          const isDefault = group.groupKey === DEFAULT_GROUP_KEY;
+          // 그룹 라벨: 명시 그룹이면 group.label, default 그룹이면 q.title 폴백
+          const groupLabel = isDefault ? q.title : (group.label || q.title);
+          // if (!q.questionCode) continue 가드가 위에 있어 항상 string 이지만 타입을 명확히 한다
+          const qCode = q.questionCode!;
+          group.cells.forEach((cell, idx) => {
+            const code = cell.spssNumericCode ?? idx + 1;
+            // 변수명: default 그룹이면 buildCheckboxItemVarName(질문코드, undefined, i) — 기존 checkbox 하위호환
+            //         명시 그룹이면 질문코드_groupKey_그룹내1-based
+            const varName = isDefault
+              ? buildCheckboxItemVarName(qCode, undefined, idx)
+              : `${qCode}_${group.groupKey}_${idx + 1}`;
+            // 보기 라벨: choiceLabel > content > '(라벨 없음)'
+            const optLabel = (cell.choiceLabel ?? '').trim() || (cell.content ?? '').trim() || '(라벨 없음)';
+            columns.push({
+              spssVarName: varName,
+              questionText: q.title,
+              // optionLabel 에 그룹 컨텍스트를 포함시켜 SPSS 변수 라벨로 바로 사용 가능하게 함
+              optionLabel: `${groupLabel} - ${optLabel}`,
+              questionId: q.id,
+              type: 'choice-group-item',
+              choiceGroupKey: group.groupKey,
+              choiceGroupMemberCellId: cell.id,
+              choiceGroupMemberCode: code,
+              optionIndex: idx,
+            });
+            // allowTextInput 사이드카: 기존 checkbox 패턴과 동일
+            if (cell.allowTextInput) {
+              const varNumber = cell.spssNumericCode != null ? String(cell.spssNumericCode) : String(idx + 1);
+              columns.push({
+                spssVarName: buildOptionTextVarName(varName, varNumber),
+                questionText: q.title,
+                optionLabel: `${optLabel} (텍스트)`,
+                questionId: q.id,
+                type: 'option-text',
+                optionId: cell.id,
+              });
+            }
+          });
+        }
+      }
+    } else if (q.type === 'checkbox') {
+      // choiceGroups 없는 순수 checkbox 질문 — 기존 checkbox-item 경로 (하위호환)
       const opts = resolveChoiceOptions(q);
       for (let i = 0; i < opts.length; i++) {
         const opt = opts[i];
@@ -168,49 +264,6 @@ export function generateSPSSColumns(questions: Question[]): SPSSExportColumn[] {
           optionLabel: '기타 입력',
           questionId: q.id,
           type: 'other-text',
-        });
-      }
-    } else if (q.type === 'radio' && isGroupedChoiceQuestion(q)) {
-      // choiceGroups 기반 radio — 그룹별 변수 1개씩 생성
-      for (const group of collectChoiceGroups(q)) {
-        // checkbox 그룹은 Task 4에서 정식 구현 예정. 현재는 skip하여 radio 전제 로직 보호.
-        if (group.type !== 'radio') continue;
-        const cellValueMap: Record<string, number> = {};
-        const valueLabels: Array<{ value: number; label: string }> = [];
-        group.cells.forEach((cell, idx) => {
-          const code = cell.spssNumericCode ?? idx + 1;
-          cellValueMap[cell.id] = code;
-          valueLabels.push({
-            value: code,
-            label: (cell.choiceLabel ?? '').trim() || (cell.content ?? '').trim() || '(라벨 없음)',
-          });
-        });
-        const isDefault = group.groupKey === DEFAULT_GROUP_KEY;
-        const groupVarName = isDefault ? q.questionCode : `${q.questionCode}_${group.groupKey}`;
-        columns.push({
-          spssVarName: groupVarName,
-          questionText: q.title,
-          optionLabel: group.label || q.title,
-          questionId: q.id,
-          type: 'choice-group',
-          choiceGroupKey: group.groupKey,
-          choiceGroupCellValueMap: cellValueMap,
-          choiceGroupValueLabels: valueLabels,
-        });
-        // allowTextInput 멤버 셀마다 STRING 사이드카 텍스트 변수 생성.
-        // 저장 경로는 __optTexts__[questionId][cell.id] 로 비그룹과 동일하므로
-        // optionId=cell.id 를 그대로 사용해 기존 option-text 추출 case 가 동작한다.
-        group.cells.forEach((cell, idx) => {
-          if (!cell.allowTextInput) return;
-          const varNumber = cell.spssNumericCode != null ? String(cell.spssNumericCode) : String(idx + 1);
-          columns.push({
-            spssVarName: buildOptionTextVarName(groupVarName, varNumber),
-            questionText: q.title,
-            optionLabel: `${(cell.choiceLabel ?? '').trim() || (cell.content ?? '').trim() || '(라벨 없음)'} (텍스트)`,
-            questionId: q.id,
-            type: 'option-text',
-            optionId: cell.id,
-          });
         });
       }
     } else if (q.type === 'radio' || q.type === 'select') {
@@ -767,6 +820,17 @@ export function buildDataRow(
         const cellId = groupAnswer[col.choiceGroupKey ?? ''];
         if (!cellId) return null;
         return col.choiceGroupCellValueMap?.[cellId] ?? null;
+      }
+
+      case 'choice-group-item': {
+        // rawValue는 그룹별 응답 맵: { groupKey: string[] (선택 cellId 목록), ... }
+        // 이 보기의 그룹 응답 배열에 해당 cellId 가 포함되면 counted 코드, 아니면 null.
+        if (rawValue == null || typeof rawValue !== 'object' || Array.isArray(rawValue)) return null;
+        const groupAnswer = rawValue as Record<string, unknown>;
+        const groupVal = groupAnswer[col.choiceGroupKey ?? ''];
+        if (!Array.isArray(groupVal)) return null;
+        const selected = groupVal as string[];
+        return selected.includes(col.choiceGroupMemberCellId ?? '') ? (col.choiceGroupMemberCode ?? null) : null;
       }
 
       case 'radio-group': {

--- a/src/lib/analytics/spss-excel-export.ts
+++ b/src/lib/analytics/spss-excel-export.ts
@@ -209,11 +209,12 @@ export function generateSPSSColumns(questions: Question[]): SPSSExportColumn[] {
               choiceGroupMemberCode: code,
               optionIndex: idx,
             });
-            // allowTextInput 사이드카: 기존 checkbox 패턴과 동일
+            // allowTextInput 사이드카: base 는 그룹 변수명 접두(질문코드[_groupKey]).
+            // default 그룹은 기존 비그룹 checkbox 사이드카(Q8_1_text)와 동일해야 한다 — 하위호환.
             if (cell.allowTextInput) {
-              const varNumber = cell.spssNumericCode != null ? String(cell.spssNumericCode) : String(idx + 1);
+              const sidecarBase = isDefault ? qCode : `${qCode}_${group.groupKey}`;
               columns.push({
-                spssVarName: buildOptionTextVarName(varName, varNumber),
+                spssVarName: buildOptionTextVarName(sidecarBase, String(idx + 1)),
                 questionText: q.title,
                 optionLabel: `${optLabel} (텍스트)`,
                 questionId: q.id,

--- a/src/lib/spss/mrsets-syntax.ts
+++ b/src/lib/spss/mrsets-syntax.ts
@@ -1,5 +1,6 @@
 import type { SPSSExportColumn } from '@/lib/analytics/spss-excel-export';
 import type { Question, TableCell } from '@/types/survey';
+import { DEFAULT_GROUP_KEY } from '@/utils/choice-group-helpers';
 
 /** 질문의 tableRowsData에서 셀 id로 셀을 찾는다 */
 function findTableCellById(question: Question | undefined, cellId: string): TableCell | undefined {
@@ -75,6 +76,44 @@ export function generateMrsetsSyntax(
     entries.push({
       name: cell.cellCode,
       label: cell.exportLabel || cell.cellCode,
+      variables: cols.map((c) => c.spssVarName),
+    });
+  }
+
+  // choice-group-item: (questionId, choiceGroupKey) 로 묶어 MCGROUP 생성.
+  // 그룹 라벨은 컬럼의 optionLabel 에서 추출한다 — generateSPSSColumns 에서
+  // optionLabel = "그룹라벨 - 보기라벨" 형식으로 설정되어 있으므로,
+  // 첫 번째 멤버의 optionLabel 을 파싱하는 대신 question.choiceGroups 에서 직접 lookup 한다.
+  // 세트명: default 그룹이면 $질문코드_default, 명시 그룹이면 $질문코드_groupKey.
+  type CgiGroupKey = `${string}::${string}`; // questionId::groupKey
+  const byCgiGroup = new Map<CgiGroupKey, SPSSExportColumn[]>();
+  for (const col of columns) {
+    if (col.type !== 'choice-group-item') continue;
+    if (!col.choiceGroupKey) continue;
+    const key: CgiGroupKey = `${col.questionId}::${col.choiceGroupKey}`;
+    const list = byCgiGroup.get(key) ?? [];
+    list.push(col);
+    byCgiGroup.set(key, list);
+  }
+
+  for (const [key, cols] of byCgiGroup) {
+    const [questionId, groupKey] = key.split('::') as [string, string];
+    const question = questionMap.get(questionId);
+    if (!question?.questionCode) continue;
+    // MCGROUP 세트명: default 그룹은 questionCode_default, 명시 그룹은 questionCode_groupKey
+    const setName = `${question.questionCode}_${groupKey}`;
+    // LABEL: question.choiceGroups 에서 그룹 라벨 lookup;
+    // default 그룹이면 question.exportLabel || question.title 폴백
+    let groupLabel: string;
+    if (groupKey === DEFAULT_GROUP_KEY) {
+      groupLabel = question.exportLabel || question.title;
+    } else {
+      const groupDef = (question.choiceGroups ?? []).find((g) => g.groupKey === groupKey);
+      groupLabel = groupDef?.label || question.exportLabel || question.title;
+    }
+    entries.push({
+      name: setName,
+      label: groupLabel,
       variables: cols.map((c) => c.spssVarName),
     });
   }

--- a/src/lib/spss/mrsets-syntax.ts
+++ b/src/lib/spss/mrsets-syntax.ts
@@ -100,8 +100,13 @@ export function generateMrsetsSyntax(
     const [questionId, groupKey] = key.split('::') as [string, string];
     const question = questionMap.get(questionId);
     if (!question?.questionCode) continue;
-    // MCGROUP 세트명: default 그룹은 questionCode_default, 명시 그룹은 questionCode_groupKey
-    const setName = `${question.questionCode}_${groupKey}`;
+    // MCGROUP 세트명: 명시 그룹은 questionCode_groupKey. default 그룹(미소속 셀)은
+    // 그룹 도입 전과 동일한 questionCode — 변수명(Q8_1...)과 마찬가지로 하위호환 유지.
+    // (그룹 있는 질문은 checkbox-item 을 emit 하지 않으므로 질문 단위 세트와 충돌 없음)
+    const setName =
+      groupKey === DEFAULT_GROUP_KEY
+        ? question.questionCode
+        : `${question.questionCode}_${groupKey}`;
     // LABEL: question.choiceGroups 에서 그룹 라벨 lookup;
     // default 그룹이면 question.exportLabel || question.title 폴백
     let groupLabel: string;

--- a/src/lib/spss/sav-builder.ts
+++ b/src/lib/spss/sav-builder.ts
@@ -79,6 +79,13 @@ export function buildValueLabels(
       return [...col.choiceGroupValueLabels].sort((a, b) => a.value - b.value);
     }
 
+    case 'choice-group-item': {
+      // choice-group-item: 이 보기의 counted 코드와 '선택' 라벨 1개만 — checkbox-item 과 동일 형태.
+      const code = col.choiceGroupMemberCode;
+      if (code == null) return undefined;
+      return [{ value: code, label: '선택' }];
+    }
+
     case 'table-cell': {
       if (col.tableCellType === 'input') return undefined;
 

--- a/src/lib/spss/variable-meta.ts
+++ b/src/lib/spss/variable-meta.ts
@@ -35,6 +35,7 @@ export function resolveVarType(col: SPSSExportColumn, question: Question | undef
     case 'ranking-rank':
     case 'radio-group':
     case 'choice-group':
+    case 'choice-group-item':
     case 'table-cell-ranking':
       return VariableType.Numeric;
 
@@ -92,6 +93,11 @@ export function resolveMeasure(col: SPSSExportColumn, question: Question | undef
     return VariableMeasure.Nominal;
   }
 
+  // choice-group-item (checkbox 그룹 기반 보기별 counted 변수) — 명목척도
+  if (col.type === 'choice-group-item') {
+    return VariableMeasure.Nominal;
+  }
+
   // 숫자 단답형(numericText) 은 척도(Continuous)
   if (col.type === 'text' && col.numericText) {
     return VariableMeasure.Continuous;
@@ -141,10 +147,19 @@ export function buildLabel(col: SPSSExportColumn): string {
         ? `${col.questionText} - ${col.optionLabel}`
         : col.questionText;
     case 'radio-group':
-    case 'choice-group':
       return col.optionLabel
         ? `${col.questionText} - ${col.optionLabel}`
         : col.questionText;
+    case 'choice-group':
+      // M1 fix: 그룹 라벨이 없어 optionLabel === questionText 인 경우 이중화 방지.
+      // 예) 그룹 라벨 미설정 시 optionLabel = q.title → "제목 - 제목" 방지.
+      return col.optionLabel && col.optionLabel !== col.questionText
+        ? `${col.questionText} - ${col.optionLabel}`
+        : col.questionText;
+    case 'choice-group-item':
+      // optionLabel 이 "그룹라벨 - 보기라벨" 을 이미 포함하므로 그대로 반환한다.
+      // (questionText prefix 를 붙이면 "질문제목 - 그룹라벨 - 보기라벨" 이 되어 장황해짐)
+      return col.optionLabel || col.questionText;
     default:
       return col.questionText;
   }

--- a/src/lib/survey/answer-validation.ts
+++ b/src/lib/survey/answer-validation.ts
@@ -1,7 +1,7 @@
 import type { Question } from '@/types/survey';
 import {
   isGroupedChoiceQuestion,
-  collectRadioGroups,
+  collectChoiceGroups,
 } from '@/utils/choice-group-helpers';
 
 /**
@@ -43,7 +43,9 @@ export function isQuestionAnswered(question: Question, response: unknown): boole
       // 그룹별 선택 radio: 모든 그룹(default 포함)에 선택이 있어야 충족
       if (isGroupedChoiceQuestion(question)) {
         const map = (response ?? {}) as Record<string, unknown>;
-        return collectRadioGroups(question).every(
+        // Task 3에서 그룹 type별로 검증 로직을 분리 예정.
+        // 현재는 radio 그룹 전제의 string 존재 여부만 확인한다(동작 무변화).
+        return collectChoiceGroups(question).every(
           (g) => typeof map[g.groupKey] === 'string' && map[g.groupKey] !== '',
         );
       }

--- a/src/lib/survey/answer-validation.ts
+++ b/src/lib/survey/answer-validation.ts
@@ -40,24 +40,34 @@ export function isQuestionAnswered(question: Question, response: unknown): boole
     case 'textarea':
       return typeof response === 'string' && response.trim().length > 0;
     case 'radio':
-      // 그룹별 선택 radio: 모든 그룹(default 포함)에 선택이 있어야 충족
+    // fallthrough: checkbox 질문도 choiceGroups 가 있으면 grouped 경로를 밟는다.
+    case 'checkbox':
+      // 그룹별 선택(radio 또는 checkbox 그룹 1개 이상): 모든 그룹에 선택이 있어야 충족.
+      // 그룹 type별 검증:
+      //   - radio 그룹: 비어있지 않은 string 값이 있어야 한다.
+      //   - checkbox 그룹: 1개 이상의 요소를 가진 배열이어야 한다.
       if (isGroupedChoiceQuestion(question)) {
         const map = (response ?? {}) as Record<string, unknown>;
-        // Task 3에서 그룹 type별로 검증 로직을 분리 예정.
-        // 현재는 radio 그룹 전제의 string 존재 여부만 확인한다(동작 무변화).
-        return collectChoiceGroups(question).every(
-          (g) => typeof map[g.groupKey] === 'string' && map[g.groupKey] !== '',
-        );
+        return collectChoiceGroups(question).every((g) => {
+          if (g.type === 'checkbox') {
+            return Array.isArray(map[g.groupKey]) && (map[g.groupKey] as unknown[]).length > 0;
+          }
+          // radio 그룹
+          return typeof map[g.groupKey] === 'string' && map[g.groupKey] !== '';
+        });
       }
+      // 비그룹 checkbox — 기존 배열 + minSelections 검증
+      if (question.type === 'checkbox') {
+        if (!Array.isArray(response) || response.length === 0) return false;
+        if (question.minSelections !== undefined && question.minSelections > 0) {
+          return response.length >= question.minSelections;
+        }
+        return true;
+      }
+      // 비그룹 radio
       return response !== null && response !== undefined && response !== '';
     case 'select':
       return response !== null && response !== undefined && response !== '';
-    case 'checkbox':
-      if (!Array.isArray(response) || response.length === 0) return false;
-      if (question.minSelections !== undefined && question.minSelections > 0) {
-        return response.length >= question.minSelections;
-      }
-      return true;
     case 'multiselect':
       return Array.isArray(response) && response.length > 0;
     case 'table':

--- a/src/utils/branch-logic.ts
+++ b/src/utils/branch-logic.ts
@@ -138,14 +138,20 @@ function getBranchRuleForRadio(question: Question, response: unknown): BranchRul
   const options = resolveChoiceOptions(question);
   if (!options.length) return null;
 
-  // 그룹별 선택 모드: 응답 맵의 값 목록(선택 cell.id 들)을 대상으로 검색
+  // 그룹별 선택 모드: 응답 맵의 값들을 flat 해서 선택된 모든 cell.id 를 추출.
+  // radio 그룹 값 = string, checkbox 그룹 값 = string[] — .flat() 으로 통합.
   if (
     isGroupedChoiceQuestion(question) &&
     typeof response === 'object' &&
     response !== null &&
     !Array.isArray(response)
   ) {
-    const selectedValues = Object.values(response as Record<string, string>);
+    const selectedValues = Object.values(response as Record<string, string | string[]>)
+      .flatMap((v): string[] => {
+        if (typeof v === 'string' && v !== '') return [v];
+        if (Array.isArray(v)) return v.filter((s): s is string => typeof s === 'string');
+        return [];
+      });
     const selectedOption = options.find(
       (opt) => selectedValues.includes(opt.value as string) && opt.branchRule,
     );
@@ -164,15 +170,40 @@ function getBranchRuleForRadio(question: Question, response: unknown): BranchRul
 }
 
 /**
- * 체크박스 응답의 분기 규칙 찾기
- * 여러 옵션이 선택된 경우 첫 번째 branchRule을 우선 적용
+ * 체크박스 응답의 분기 규칙 찾기.
+ * 여러 옵션이 선택된 경우 첫 번째 branchRule 을 우선 적용.
+ * grouped 응답 맵(checkbox 질문에 choiceGroups 존재) 도 지원한다.
  */
 function getBranchRuleForCheckbox(question: Question, response: unknown): BranchRule | null {
   // manual: question.options 그대로 / table-source: choice_opt 셀에서 변환된 옵션
   const options = resolveChoiceOptions(question);
-  if (!options.length || !Array.isArray(response)) return null;
+  if (!options.length) return null;
 
-  // 체크된 값들 추출
+  // 그룹별 선택 모드: checkbox 질문도 choiceGroups 가 있으면 grouped 맵일 수 있다.
+  if (
+    isGroupedChoiceQuestion(question) &&
+    typeof response === 'object' &&
+    response !== null &&
+    !Array.isArray(response)
+  ) {
+    // 맵 값 flat — checkbox 그룹 값은 string[], radio 그룹 값은 string
+    const selectedValues = Object.values(response as Record<string, string | string[]>)
+      .flatMap((v): string[] => {
+        if (typeof v === 'string' && v !== '') return [v];
+        if (Array.isArray(v)) return v.filter((s): s is string => typeof s === 'string');
+        return [];
+      });
+    for (const option of options) {
+      if (selectedValues.includes(option.value as string) && option.branchRule) {
+        return option.branchRule;
+      }
+    }
+    return null;
+  }
+
+  if (!Array.isArray(response)) return null;
+
+  // 체크된 값들 추출 (비그룹 checkbox 경로)
   const checkedValues = response.map((val: unknown) =>
     typeof val === 'object' && val !== null && 'selectedValue' in val
       ? (val as { selectedValue: string }).selectedValue

--- a/src/utils/choice-group-helpers.ts
+++ b/src/utils/choice-group-helpers.ts
@@ -4,15 +4,22 @@ import { collectChoiceOptCells } from '@/utils/choice-source';
 /** 그룹 미소속 choice_opt 셀의 예약 응답 키. export 변수명은 질문코드 그대로(하위호환). */
 export const DEFAULT_GROUP_KEY = 'default';
 
-/** 그룹별 응답 맵 shape: { groupKey: 선택 cellId } */
-export type GroupedChoiceAnswer = Record<string, string>;
+/**
+ * 그룹별 응답 맵 shape:
+ * - radio 그룹 키 → 선택 cellId (string)
+ * - checkbox 그룹 키 → 선택 cellId 배열 (string[])
+ */
+export type GroupedChoiceAnswer = Record<string, string | string[]>;
 
 /**
  * 이 질문의 응답이 그룹별 맵 shape인지 — 모든 경로(렌더/검증/분기/export)의
- * 하위호환 분기점. radio 그룹이 1개 이상 정의된 경우에만 true.
+ * 하위호환 분기점. radio 또는 checkbox 그룹이 1개 이상 정의된 경우 true.
+ * ranking 그룹은 제외한다 (4b-3 에서 별도 처리).
  */
 export function isGroupedChoiceQuestion(question: Question): boolean {
-  return (question.choiceGroups ?? []).some((g) => g.type === 'radio');
+  return (question.choiceGroups ?? []).some(
+    (g) => g.type === 'radio' || g.type === 'checkbox',
+  );
 }
 
 /** 셀이 속한 그룹의 groupKey. 미소속/깨진 참조는 default로 폴백. */
@@ -23,34 +30,56 @@ export function getGroupKeyOfCell(question: Question, cellId: string): string {
   return group?.groupKey ?? DEFAULT_GROUP_KEY;
 }
 
-export interface RadioGroupWithCells {
+/**
+ * 셀이 속한 그룹의 type. 미소속/깨진 참조는 질문 type 기반 default 규칙:
+ * 질문 type이 'checkbox'이면 'checkbox', 그 외는 'radio'.
+ */
+export function getGroupTypeOfCell(question: Question, cellId: string): 'radio' | 'checkbox' {
+  const defaultType = question.type === 'checkbox' ? 'checkbox' : 'radio';
+  const cell = collectChoiceOptCells(question.tableRowsData).find((c) => c.id === cellId);
+  if (!cell?.choiceGroupId) return defaultType;
+  const group = (question.choiceGroups ?? []).find((g) => g.id === cell.choiceGroupId);
+  if (!group) return defaultType;
+  // ranking 그룹에 소속된 셀도 default 규칙으로 폴백
+  if (group.type === 'ranking') return defaultType;
+  return group.type;
+}
+
+export interface ChoiceGroupWithCells {
   groupKey: string;
   label: string;
+  /** 그룹의 응답 동작: radio=단일 선택, checkbox=복수 선택 */
+  type: 'radio' | 'checkbox';
   cells: TableCell[];
 }
 
 /**
- * 질문의 radio 그룹들을 멤버 셀과 함께 반환한다 (정의 순).
- * 미소속 choice_opt 셀이 있으면 default 그룹을 마지막에 추가한다.
+ * 질문의 radio·checkbox 그룹들을 멤버 셀과 함께 반환한다 (정의 순).
+ * - ranking 그룹은 skip.
+ * - 멤버 0 그룹은 skip (prune을 비껴간 phantom 그룹 무해화).
+ * - 미소속 choice_opt 셀이 있으면 default 그룹을 마지막에 추가한다.
+ *   default 그룹의 type은 질문 type이 'checkbox'이면 'checkbox', 그 외 'radio'.
  */
-export function collectRadioGroups(question: Question): RadioGroupWithCells[] {
+export function collectChoiceGroups(question: Question): ChoiceGroupWithCells[] {
   const allCells = collectChoiceOptCells(question.tableRowsData);
-  const groups: RadioGroupWithCells[] = [];
+  const groups: ChoiceGroupWithCells[] = [];
   const claimed = new Set<string>();
 
   for (const group of question.choiceGroups ?? []) {
-    if (group.type !== 'radio') continue;
+    // ranking 그룹은 collectChoiceGroups 대상에서 제외
+    if (group.type === 'ranking') continue;
     const cells = allCells.filter((c) => c.choiceGroupId === group.id);
     // 멤버 0 그룹은 응답 불가능한 요구가 되므로 제외한다 — 행/열 삭제 등으로
     // prune 을 비껴간 phantom 그룹(이미 snapshot 에 박힌 것 포함)을 무해화.
     if (cells.length === 0) continue;
     for (const c of cells) claimed.add(c.id);
-    groups.push({ groupKey: group.groupKey, label: group.label, cells });
+    groups.push({ groupKey: group.groupKey, label: group.label, type: group.type, cells });
   }
 
   const orphans = allCells.filter((c) => !claimed.has(c.id));
   if (orphans.length > 0) {
-    groups.push({ groupKey: DEFAULT_GROUP_KEY, label: '', cells: orphans });
+    const defaultType = question.type === 'checkbox' ? 'checkbox' : 'radio';
+    groups.push({ groupKey: DEFAULT_GROUP_KEY, label: '', type: defaultType, cells: orphans });
   }
   return groups;
 }

--- a/tests/integration/choice-table-response.test.ts
+++ b/tests/integration/choice-table-response.test.ts
@@ -166,6 +166,78 @@ describe('그룹별 선택 radio 분기 로직', () => {
   });
 });
 
+/**
+ * checkbox 그룹이 포함된 grouped 응답 맵에서 branchRule 탐색.
+ * { cb1: ['cellE'] } 에서 cellE 의 branchRule 반환.
+ */
+function groupedCheckboxBranchQ(): Question {
+  return {
+    id: 'qgcb',
+    type: 'radio',
+    title: '혼합 분기 질문',
+    required: false,
+    order: 0,
+    tableColumns: [{ id: 'c1', label: '열' }],
+    tableRowsData: [
+      {
+        id: 'row1',
+        label: '',
+        cells: [
+          {
+            id: 'cellA',
+            type: 'choice_opt',
+            content: '',
+            choiceGroupId: 'grp1',
+          },
+          {
+            id: 'cellE',
+            type: 'choice_opt',
+            content: '',
+            choiceGroupId: 'grpCb',
+            branchRule: { id: 'bE', value: 'cellE', action: 'end' },
+          },
+          {
+            id: 'cellF',
+            type: 'choice_opt',
+            content: '',
+            choiceGroupId: 'grpCb',
+          },
+        ],
+      },
+    ],
+    choiceGroups: [
+      { id: 'grp1', type: 'radio', groupKey: 'rad1', label: 'Radio그룹' },
+      { id: 'grpCb', type: 'checkbox', groupKey: 'cb1', label: 'CB그룹' },
+    ],
+  } as unknown as Question;
+}
+
+describe('checkbox 그룹 분기 로직', () => {
+  it('{ cb1: [cellE] } 에서 cellE branchRule 반환', () => {
+    const q = groupedCheckboxBranchQ();
+    const rule = getBranchRuleForResponse(q, { rad1: 'cellA', cb1: ['cellE'] });
+    expect(rule?.action).toBe('end');
+  });
+
+  it('branchRule 없는 셀만 선택된 경우 null', () => {
+    const q = groupedCheckboxBranchQ();
+    const rule = getBranchRuleForResponse(q, { rad1: 'cellA', cb1: ['cellF'] });
+    expect(rule).toBeNull();
+  });
+
+  it('{ cb1: [cellE, cellF] } — cellE branchRule 반환(첫 번째 매칭)', () => {
+    const q = groupedCheckboxBranchQ();
+    const rule = getBranchRuleForResponse(q, { cb1: ['cellE', 'cellF'] });
+    expect(rule?.action).toBe('end');
+  });
+
+  it('빈 맵({})이면 null', () => {
+    const q = groupedCheckboxBranchQ();
+    const rule = getBranchRuleForResponse(q, {});
+    expect(rule).toBeNull();
+  });
+});
+
 describe('choice table-source SPSS 단일/복수 변수 계약', () => {
   function radioTableQ(): Question {
     return {

--- a/tests/unit/answer-validation.test.ts
+++ b/tests/unit/answer-validation.test.ts
@@ -48,6 +48,36 @@ function groupedRadioQ(): Question {
   } as unknown as Question;
 }
 
+/**
+ * checkbox 그룹이 포함된 질문 빌더.
+ * rad1(cellA) + cb1(cellE, cellF) — radio 질문에 checkbox 그룹 혼재
+ */
+function groupedWithCheckboxQ(): Question {
+  return {
+    id: 'qgcb',
+    type: 'radio',
+    title: '혼합 그룹',
+    required: true,
+    order: 0,
+    tableColumns: [{ id: 'c1', label: '열' }],
+    tableRowsData: [
+      {
+        id: 'r1',
+        label: '',
+        cells: [
+          { id: 'cellA', type: 'choice_opt', content: '', choiceGroupId: 'grp1' },
+          { id: 'cellE', type: 'choice_opt', content: '', choiceGroupId: 'grpCb' },
+          { id: 'cellF', type: 'choice_opt', content: '', choiceGroupId: 'grpCb' },
+        ],
+      },
+    ],
+    choiceGroups: [
+      { id: 'grp1', type: 'radio', groupKey: 'rad1', label: 'Radio그룹' },
+      { id: 'grpCb', type: 'checkbox', groupKey: 'cb1', label: 'CB그룹' },
+    ],
+  } as unknown as Question;
+}
+
 describe('isQuestionAnswered (survey-response-flow 추출 characterization)', () => {
   // 모든 타입 공통: null/undefined 응답은 미응답.
   it('응답값이 undefined/null 이면 모든 타입에서 미응답', () => {
@@ -249,5 +279,35 @@ describe('isQuestionAnswered — 그룹별 선택 radio (choiceGroups)', () => {
     expect(isQuestionAnswered(withPhantom, { rad1: 'cellA' })).toBe(true);
     // 아무것도 선택 안 하면 미응답
     expect(isQuestionAnswered(withPhantom, {})).toBe(false);
+  });
+});
+
+describe('isQuestionAnswered — checkbox 그룹 검증', () => {
+  it('cb1 에 1개 이상 선택 + rad1 선택 → 응답 충족', () => {
+    const gq = groupedWithCheckboxQ();
+    expect(isQuestionAnswered(gq, { rad1: 'cellA', cb1: ['cellE'] })).toBe(true);
+    expect(isQuestionAnswered(gq, { rad1: 'cellA', cb1: ['cellE', 'cellF'] })).toBe(true);
+  });
+
+  it('cb1 키 없음 → 미응답', () => {
+    const gq = groupedWithCheckboxQ();
+    // rad1만 있고 cb1 없음
+    expect(isQuestionAnswered(gq, { rad1: 'cellA' })).toBe(false);
+  });
+
+  it('cb1 빈 배열 → 미응답', () => {
+    const gq = groupedWithCheckboxQ();
+    expect(isQuestionAnswered(gq, { rad1: 'cellA', cb1: [] })).toBe(false);
+  });
+
+  it('cb1 값이 배열이 아닌 경우(잘못된 형태) → 미응답', () => {
+    const gq = groupedWithCheckboxQ();
+    // cb1 에 string이 들어간 잘못된 응답 — 배열이어야 충족
+    expect(isQuestionAnswered(gq, { rad1: 'cellA', cb1: 'cellE' })).toBe(false);
+  });
+
+  it('radio 그룹 검증 기존 동작 유지: rad1 없으면 미응답', () => {
+    const gq = groupedWithCheckboxQ();
+    expect(isQuestionAnswered(gq, { cb1: ['cellE'] })).toBe(false);
   });
 });

--- a/tests/unit/domains/spss/choice-group-export.test.ts
+++ b/tests/unit/domains/spss/choice-group-export.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { buildDataRows, generateSPSSColumns } from '@/lib/analytics/spss-excel-export';
+import { generateMrsetsSyntax } from '@/lib/spss/mrsets-syntax';
+import { buildValueLabels } from '@/lib/spss/sav-builder';
+import { buildLabel, resolveMeasure, resolveVarType } from '@/lib/spss/variable-meta';
 import type { Question, SurveySubmission } from '@/types/survey';
+import { VariableMeasure, VariableType } from 'sav-writer';
 
 // radio choiceGroups 가 있는 질문 픽스처
 const grouped = {
@@ -202,5 +206,361 @@ describe('radio 옵션 그룹 export — buildDataRows 응답값 변환', () => 
     if (row == null) throw new Error('row 없음');
     const rad1Col = cols.findIndex((c) => c.spssVarName === 'Q5_rad1');
     expect(row[rad1Col]).toBeNull();
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// checkbox 그룹 픽스처
+// ────────────────────────────────────────────────────────────
+
+// rad1(radio) + cb1(checkbox) 혼재 질문: Q7
+const mixedGroupsQuestion = {
+  id: 'q7',
+  type: 'radio',
+  title: '구매처',
+  required: false,
+  order: 1,
+  questionCode: 'Q7',
+  choiceGroups: [
+    { id: 'gr1', groupKey: 'rad1', type: 'radio', label: '보유여부' },
+    { id: 'gc1', groupKey: 'cb1', type: 'checkbox', label: '구매처' },
+  ],
+  tableRowsData: [
+    {
+      id: 'r1',
+      label: '행1',
+      cells: [
+        // rad1 그룹 멤버 (radio)
+        { id: 'cellR', content: '있음', type: 'choice_opt', choiceGroupId: 'gr1', spssNumericCode: 1 },
+        // cb1 그룹 멤버 (checkbox)
+        { id: 'cellE', content: '보기E', type: 'choice_opt', choiceGroupId: 'gc1', spssNumericCode: 5 },
+        { id: 'cellF', content: '보기F', type: 'choice_opt', choiceGroupId: 'gc1', spssNumericCode: 7 },
+      ],
+    },
+  ],
+} as unknown as Question;
+
+// checkbox 질문: 명시 그룹 cb1 + default 미소속 셀
+const checkboxGroupQuestion = {
+  id: 'q8',
+  type: 'checkbox',
+  title: '이용경험',
+  required: false,
+  order: 2,
+  questionCode: 'Q8',
+  choiceGroups: [
+    { id: 'gc2', groupKey: 'cb2', type: 'checkbox', label: '채널' },
+  ],
+  tableRowsData: [
+    {
+      id: 'r1',
+      label: '행1',
+      cells: [
+        // gc2 소속
+        { id: 'cellG', content: '온라인', type: 'choice_opt', choiceGroupId: 'gc2', spssNumericCode: 1 },
+        { id: 'cellH', content: '오프라인', type: 'choice_opt', choiceGroupId: 'gc2', spssNumericCode: 2 },
+        // 미소속 → default 그룹
+        { id: 'cellI', content: '기타', type: 'choice_opt' },
+      ],
+    },
+  ],
+} as unknown as Question;
+
+// 그룹 없는 순수 checkbox 질문: 하위호환 확인용
+const plainCheckboxQuestion = {
+  id: 'q9',
+  type: 'checkbox',
+  title: '매체',
+  required: false,
+  order: 3,
+  questionCode: 'Q9',
+  options: [
+    { id: 'o1', label: 'TV', value: 'o1', optionCode: '1', spssNumericCode: 1 },
+    { id: 'o2', label: '라디오', value: 'o2', optionCode: '2', spssNumericCode: 2 },
+  ],
+} as unknown as Question;
+
+// ────────────────────────────────────────────────────────────
+// Task 4 — checkbox 그룹 generateSPSSColumns
+// ────────────────────────────────────────────────────────────
+
+describe('checkbox 그룹 export — generateSPSSColumns', () => {
+  it('cb1 그룹은 멤버 셀별 choice-group-item 변수를 생성한다', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const cbCols = cols.filter((c) => c.type === 'choice-group-item' && c.choiceGroupKey === 'cb1');
+    expect(cbCols.length).toBe(2);
+    expect(cbCols.map((c) => c.spssVarName)).toEqual(['Q7_cb1_1', 'Q7_cb1_2']);
+  });
+
+  it('cb1 변수 counted 코드는 spssNumericCode를 따른다', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const cbCols = cols.filter((c) => c.type === 'choice-group-item' && c.choiceGroupKey === 'cb1');
+    expect(cbCols[0]?.choiceGroupMemberCode).toBe(5); // cellE
+    expect(cbCols[1]?.choiceGroupMemberCode).toBe(7); // cellF
+  });
+
+  it('cb1 변수 optionLabel은 "그룹라벨 - 보기라벨" 형식이다', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const col0 = cols.find((c) => c.spssVarName === 'Q7_cb1_1');
+    expect(col0?.optionLabel).toBe('구매처 - 보기E');
+  });
+
+  it('rad1+cb1 혼재 질문에서 choice-group(radio) 과 choice-group-item(checkbox) 이 공존한다', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const cgCols = cols.filter((c) => c.type === 'choice-group');
+    const cgiCols = cols.filter((c) => c.type === 'choice-group-item');
+    expect(cgCols.length).toBe(1);   // rad1
+    expect(cgiCols.length).toBe(2);  // cb1 멤버
+  });
+
+  it('choiceGroupMemberCellId 는 해당 보기의 cellId이다', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const col0 = cols.find((c) => c.spssVarName === 'Q7_cb1_1');
+    const col1 = cols.find((c) => c.spssVarName === 'Q7_cb1_2');
+    expect(col0?.choiceGroupMemberCellId).toBe('cellE');
+    expect(col1?.choiceGroupMemberCellId).toBe('cellF');
+  });
+
+  it('optionIndex 는 그룹 내 0-based 순서이다', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const col0 = cols.find((c) => c.spssVarName === 'Q7_cb1_1');
+    const col1 = cols.find((c) => c.spssVarName === 'Q7_cb1_2');
+    expect(col0?.optionIndex).toBe(0);
+    expect(col1?.optionIndex).toBe(1);
+  });
+
+  it('checkbox 질문의 default 그룹 변수명은 buildCheckboxItemVarName(questionCode, undefined, i) 규칙을 따른다', () => {
+    // checkboxGroupQuestion: cellI 는 미소속 → default 그룹 내 i=0 → Q8_1
+    const cols = generateSPSSColumns([checkboxGroupQuestion]);
+    const defCols = cols.filter((c) => c.type === 'choice-group-item' && c.choiceGroupKey === 'default');
+    expect(defCols.length).toBe(1);
+    // buildCheckboxItemVarName(Q8, undefined, 0) = Q8_1
+    expect(defCols[0]?.spssVarName).toBe('Q8_1');
+  });
+
+  it('그룹 없는 checkbox 질문은 기존 checkbox-item 경로를 그대로 사용한다 — 하위호환', () => {
+    const cols = generateSPSSColumns([plainCheckboxQuestion]);
+    const types = cols.filter((c) => c.questionId === 'q9').map((c) => c.type);
+    expect(types).toEqual(['checkbox-item', 'checkbox-item']);
+    expect(cols.filter((c) => c.questionId === 'q9').map((c) => c.spssVarName)).toEqual(['Q9_1', 'Q9_2']);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Task 4 — checkbox 그룹 buildDataRows
+// ────────────────────────────────────────────────────────────
+
+describe('checkbox 그룹 export — buildDataRows 응답값 변환', () => {
+  it('cb1 응답에 cellE 포함 시 Q7_cb1_1=5, cellF 미포함 시 Q7_cb1_2=null', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const sub = makeSubmission({ q7: { cb1: ['cellE'] } });
+    const rows = buildDataRows(cols, [mixedGroupsQuestion], [sub]);
+    const row = rows[0];
+    if (row == null) throw new Error('row 없음');
+    const idx1 = cols.findIndex((c) => c.spssVarName === 'Q7_cb1_1');
+    const idx2 = cols.findIndex((c) => c.spssVarName === 'Q7_cb1_2');
+    expect(row[idx1]).toBe(5);
+    expect(row[idx2]).toBeNull();
+  });
+
+  it('두 보기 모두 선택 시 양쪽 counted 코드 반환', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const sub = makeSubmission({ q7: { cb1: ['cellE', 'cellF'] } });
+    const rows = buildDataRows(cols, [mixedGroupsQuestion], [sub]);
+    const row = rows[0];
+    if (row == null) throw new Error('row 없음');
+    const idx1 = cols.findIndex((c) => c.spssVarName === 'Q7_cb1_1');
+    const idx2 = cols.findIndex((c) => c.spssVarName === 'Q7_cb1_2');
+    expect(row[idx1]).toBe(5);
+    expect(row[idx2]).toBe(7);
+  });
+
+  it('레거시 string 응답(그룹 맵 아님) → null 안전 처리', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const sub = makeSubmission({ q7: 'cellE' });
+    const rows = buildDataRows(cols, [mixedGroupsQuestion], [sub]);
+    const row = rows[0];
+    if (row == null) throw new Error('row 없음');
+    const idx1 = cols.findIndex((c) => c.spssVarName === 'Q7_cb1_1');
+    expect(row[idx1]).toBeNull();
+  });
+
+  it('응답 없음(null) → null', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const sub = makeSubmission({ q7: null });
+    const rows = buildDataRows(cols, [mixedGroupsQuestion], [sub]);
+    const row = rows[0];
+    if (row == null) throw new Error('row 없음');
+    const idx1 = cols.findIndex((c) => c.spssVarName === 'Q7_cb1_1');
+    expect(row[idx1]).toBeNull();
+  });
+
+  it('레거시 비객체 응답(배열이지만 그룹 맵 아님) → null 안전 처리', () => {
+    // 기존 checkbox 응답 shape(문자열 배열)이 잘못 들어온 경우
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const sub = makeSubmission({ q7: ['cellE', 'cellF'] });
+    // rawValue 가 배열이면 typeof === 'object' && Array.isArray 처리
+    // choice-group-item case 는 Array 응답을 그룹 맵이 아니라고 판단해야 null
+    const rows = buildDataRows(cols, [mixedGroupsQuestion], [sub]);
+    const row = rows[0];
+    if (row == null) throw new Error('row 없음');
+    const idx1 = cols.findIndex((c) => c.spssVarName === 'Q7_cb1_1');
+    expect(row[idx1]).toBeNull();
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Task 4 — variable-meta (buildLabel, resolveVarType, resolveMeasure)
+// ────────────────────────────────────────────────────────────
+
+describe('checkbox 그룹 export — variable-meta', () => {
+  it('choice-group-item 은 Numeric 타입이다', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const col = cols.find((c) => c.spssVarName === 'Q7_cb1_1');
+    if (!col) throw new Error('컬럼 없음');
+    expect(resolveVarType(col, mixedGroupsQuestion)).toBe(VariableType.Numeric);
+  });
+
+  it('choice-group-item 은 Nominal 측정수준이다', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const col = cols.find((c) => c.spssVarName === 'Q7_cb1_1');
+    if (!col) throw new Error('컬럼 없음');
+    expect(resolveMeasure(col, mixedGroupsQuestion)).toBe(VariableMeasure.Nominal);
+  });
+
+  it('choice-group-item buildLabel 은 optionLabel("그룹라벨 - 보기라벨") 을 그대로 반환한다', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const col = cols.find((c) => c.spssVarName === 'Q7_cb1_1');
+    if (!col) throw new Error('컬럼 없음');
+    // optionLabel 이 "구매처 - 보기E" 이므로 buildLabel 은 그대로 반환
+    expect(buildLabel(col)).toBe('구매처 - 보기E');
+  });
+
+  it('M1 fix: radio 그룹 라벨 미설정 시 buildLabel 이 "제목 - 제목" 이중화 안 됨', () => {
+    // 그룹 라벨 없는 radio 그룹 — optionLabel === questionText 케이스
+    const noLabelGroupQ = {
+      ...mixedGroupsQuestion,
+      id: 'q_m1',
+      questionCode: 'QM1',
+      choiceGroups: [
+        { id: 'gm1', groupKey: 'rad1', type: 'radio', label: '' }, // 라벨 없음
+      ],
+      tableRowsData: [
+        {
+          id: 'r1',
+          label: '행1',
+          cells: [
+            { id: 'cM1', content: '있음', type: 'choice_opt', choiceGroupId: 'gm1', spssNumericCode: 1 },
+          ],
+        },
+      ],
+    } as unknown as Question;
+    const cols = generateSPSSColumns([noLabelGroupQ]);
+    const col = cols.find((c) => c.type === 'choice-group');
+    if (!col) throw new Error('컬럼 없음');
+    // optionLabel 이 group.label || q.title → '' || '구매처' = '구매처'
+    // buildLabel: choice-group → questionText - optionLabel 이면 "구매처 - 구매처" 이중화 발생
+    // M1 fix: optionLabel === questionText 이면 questionText 한 번만 반환해야 한다
+    const label = buildLabel(col);
+    expect(label).not.toBe(`${noLabelGroupQ.title} - ${noLabelGroupQ.title}`);
+    expect(label).toBe(noLabelGroupQ.title);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Task 4 — value labels (buildValueLabels + buildCodebookValueLabel)
+// ────────────────────────────────────────────────────────────
+
+describe('checkbox 그룹 export — value labels', () => {
+  it('choice-group-item buildValueLabels 는 [{ value: code, label: "선택" }] 형식이다', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const col = cols.find((c) => c.spssVarName === 'Q7_cb1_1');
+    if (!col) throw new Error('컬럼 없음');
+    const labels = buildValueLabels(col, mixedGroupsQuestion);
+    expect(labels).toEqual([{ value: 5, label: '선택' }]);
+  });
+
+  it('choice-group-item buildValueLabels 는 2번째 보기도 자체 counted 코드를 갖는다', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const col = cols.find((c) => c.spssVarName === 'Q7_cb1_2');
+    if (!col) throw new Error('컬럼 없음');
+    const labels = buildValueLabels(col, mixedGroupsQuestion);
+    expect(labels).toEqual([{ value: 7, label: '선택' }]);
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Task 4 — mrsets-syntax (choice-group-item MCGROUP)
+// ────────────────────────────────────────────────────────────
+
+describe('checkbox 그룹 export — mrsets-syntax', () => {
+  it('cb1 그룹은 $Q7_cb1 이름으로 MCGROUP을 생성한다', () => {
+    const questions = [mixedGroupsQuestion];
+    const cols = generateSPSSColumns(questions);
+    const syntax = generateMrsetsSyntax(cols, questions);
+    expect(syntax).toContain('/MCGROUP NAME=$Q7_cb1');
+  });
+
+  it('cb1 MCGROUP 라벨은 그룹 라벨(구매처)을 사용한다', () => {
+    const questions = [mixedGroupsQuestion];
+    const cols = generateSPSSColumns(questions);
+    const syntax = generateMrsetsSyntax(cols, questions);
+    expect(syntax).toContain("LABEL='구매처'");
+  });
+
+  it('cb1 MCGROUP VARIABLES 에 멤버 변수명이 순서대로 포함된다', () => {
+    const questions = [mixedGroupsQuestion];
+    const cols = generateSPSSColumns(questions);
+    const syntax = generateMrsetsSyntax(cols, questions);
+    expect(syntax).toContain('VARIABLES=Q7_cb1_1 Q7_cb1_2');
+  });
+
+  it('rad1(radio) 그룹은 choice-group 이므로 MCGROUP 미생성, cb1 만 생성된다', () => {
+    const questions = [mixedGroupsQuestion];
+    const cols = generateSPSSColumns(questions);
+    const syntax = generateMrsetsSyntax(cols, questions);
+    // rad1 에 대한 세트 없음
+    expect(syntax).not.toContain('$Q7_rad1');
+    // cb1 에 대한 세트 존재
+    expect(syntax).toContain('$Q7_cb1');
+  });
+
+  it('grouepd checkbox 질문 존재 시 질문 단위 $Q7 세트가 생성되지 않는다 — 배타성', () => {
+    const questions = [mixedGroupsQuestion];
+    const cols = generateSPSSColumns(questions);
+    const syntax = generateMrsetsSyntax(cols, questions);
+    // 그룹 없는 checkbox-item 변수가 없으므로 $Q7 질문 단위 세트 미생성
+    expect(syntax).not.toMatch(/NAME=\$Q7[^_]/);
+  });
+
+  it('default cb 그룹은 $Q8_default 이름으로 MCGROUP을 생성한다', () => {
+    // checkboxGroupQuestion: gc2(cb2) + default(미소속 cellI)
+    const questions = [checkboxGroupQuestion];
+    const cols = generateSPSSColumns(questions);
+    const syntax = generateMrsetsSyntax(cols, questions);
+    // default 그룹 세트
+    expect(syntax).toContain('/MCGROUP NAME=$Q8_default');
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// Task 4 — value-labels-coverage: choice-group-item 포함
+// ────────────────────────────────────────────────────────────
+
+describe('value-labels-coverage — choice-group-item 추가', () => {
+  it('choice-group-item 컬럼은 CATEGORICAL_TYPES에 포함되어 value labels를 가진다', () => {
+    const questions = [mixedGroupsQuestion];
+    const cols = generateSPSSColumns(questions);
+    const CATEGORICAL_TYPES = new Set([
+      'single', 'checkbox-item', 'table-cell', 'choice-group', 'choice-group-item',
+    ]);
+    const cgiCols = cols.filter((c) => CATEGORICAL_TYPES.has(c.type) && c.tableCellType !== 'input');
+    // cb1 두 보기 + rad1 choice-group 합 3개 이상
+    expect(cgiCols.length).toBeGreaterThanOrEqual(3);
+    for (const col of cgiCols) {
+      const labels = buildValueLabels(col, questions.find((q) => q.id === col.questionId));
+      expect(labels, `${col.spssVarName} value labels 누락`).toBeDefined();
+      expect(labels!.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/tests/unit/domains/spss/choice-group-export.test.ts
+++ b/tests/unit/domains/spss/choice-group-export.test.ts
@@ -533,13 +533,14 @@ describe('checkbox 그룹 export — mrsets-syntax', () => {
     expect(syntax).not.toMatch(/NAME=\$Q7[^_]/);
   });
 
-  it('default cb 그룹은 $Q8_default 이름으로 MCGROUP을 생성한다', () => {
+  it('default cb 그룹은 그룹 도입 전과 동일한 $질문코드 이름으로 MCGROUP을 생성한다', () => {
     // checkboxGroupQuestion: gc2(cb2) + default(미소속 cellI)
     const questions = [checkboxGroupQuestion];
     const cols = generateSPSSColumns(questions);
     const syntax = generateMrsetsSyntax(cols, questions);
-    // default 그룹 세트
-    expect(syntax).toContain('/MCGROUP NAME=$Q8_default');
+    // 변수명(Q8_1...)과 마찬가지로 세트명도 하위호환 — 내부 예약어 default 미노출
+    expect(syntax).toContain('/MCGROUP NAME=$Q8 ');
+    expect(syntax).not.toContain('$Q8_default');
   });
 });
 

--- a/tests/unit/domains/spss/choice-group-export.test.ts
+++ b/tests/unit/domains/spss/choice-group-export.test.ts
@@ -525,7 +525,7 @@ describe('checkbox 그룹 export — mrsets-syntax', () => {
     expect(syntax).toContain('$Q7_cb1');
   });
 
-  it('grouepd checkbox 질문 존재 시 질문 단위 $Q7 세트가 생성되지 않는다 — 배타성', () => {
+  it('grouped checkbox 질문 존재 시 질문 단위 $Q7 세트가 생성되지 않는다 — 배타성', () => {
     const questions = [mixedGroupsQuestion];
     const cols = generateSPSSColumns(questions);
     const syntax = generateMrsetsSyntax(cols, questions);
@@ -563,5 +563,54 @@ describe('value-labels-coverage — choice-group-item 추가', () => {
       expect(labels, `${col.spssVarName} value labels 누락`).toBeDefined();
       expect(labels!.length).toBeGreaterThan(0);
     }
+  });
+});
+
+// ────────────────────────────────────────────────────────────
+// 최종리뷰 보강 — 혼재 단일 응답 행 + 사이드카 변수명 하위호환
+// ────────────────────────────────────────────────────────────
+
+describe('혼재 그룹 단일 응답 행 — radio와 checkbox 그룹 동시 추출', () => {
+  it('한 submission에서 rad1 1변수와 cb1 N변수가 동시에 정확히 추출된다', () => {
+    const cols = generateSPSSColumns([mixedGroupsQuestion]);
+    const sub = makeSubmission({ q7: { rad1: 'cellR', cb1: ['cellE'] } });
+    const rows = buildDataRows(cols, [mixedGroupsQuestion], [sub]);
+    const row = rows[0]!;
+    const idx = (name: string) => cols.findIndex((c) => c.spssVarName === name);
+    expect(row[idx('Q7_rad1')]).toBe(1);       // rad1 선택 cellR 코드
+    expect(row[idx('Q7_cb1_1')]).toBe(5);      // cellE 선택 counted
+    expect(row[idx('Q7_cb1_2')]).toBeNull();   // cellF 미선택 system-missing
+  });
+});
+
+describe('checkbox 그룹 allowTextInput 사이드카 — 변수명 하위호환', () => {
+  const withTextQuestion = {
+    id: 'q10',
+    type: 'checkbox',
+    title: '경로',
+    required: false,
+    order: 4,
+    questionCode: 'Q10',
+    choiceGroups: [{ id: 'gt1', groupKey: 'cb1', type: 'checkbox', label: '경로' }],
+    tableRowsData: [
+      {
+        id: 'r1',
+        label: '행1',
+        cells: [
+          { id: 'cellT', content: '보기T', type: 'choice_opt', choiceGroupId: 'gt1', spssNumericCode: 9, allowTextInput: true },
+          // 미소속(default) + 텍스트 입력 — 기존 비그룹 checkbox 사이드카 규칙과 동일해야 함
+          { id: 'cellU', content: '기타', type: 'choice_opt', allowTextInput: true },
+        ],
+      },
+    ],
+  } as unknown as Question;
+
+  it('명시 그룹 사이드카는 질문코드_groupKey_순번_text, default는 질문코드_순번_text', () => {
+    const cols = generateSPSSColumns([withTextQuestion]);
+    const names = cols.filter((c) => c.type === 'option-text').map((c) => c.spssVarName);
+    expect(names).toContain('Q10_cb1_1_text');
+    expect(names).toContain('Q10_1_text');
+    // 보기 인덱스가 base 변수명에 이중 포함되지 않는다
+    expect(names).not.toContain('Q10_cb1_1_9_text');
   });
 });

--- a/tests/unit/domains/spss/value-labels-coverage.test.ts
+++ b/tests/unit/domains/spss/value-labels-coverage.test.ts
@@ -58,6 +58,26 @@ const radioGrouped = q({
   ],
 });
 
+// checkbox 그룹 픽스처
+const checkboxGrouped = q({
+  id: 'q5',
+  questionCode: 'Q5',
+  type: 'checkbox',
+  choiceGroups: [
+    { id: 'gc1', groupKey: 'cb1', type: 'checkbox', label: '구매처' },
+  ],
+  tableRowsData: [
+    {
+      id: 'r1',
+      label: '행1',
+      cells: [
+        { id: 'cgc1', content: '온라인', type: 'choice_opt', choiceGroupId: 'gc1', spssNumericCode: 3 },
+        { id: 'cgc2', content: '오프라인', type: 'choice_opt', choiceGroupId: 'gc1', spssNumericCode: 5 },
+      ],
+    },
+  ],
+});
+
 const tableWithCells = q({
   id: 'q3',
   questionCode: 'Q3',
@@ -99,11 +119,11 @@ const tableWithCells = q({
 });
 
 describe('categorical 변수 VALUE LABELS 전수 보장', () => {
-  const questions = [radioManual, checkboxManual, tableWithCells, radioGrouped];
+  const questions = [radioManual, checkboxManual, tableWithCells, radioGrouped, checkboxGrouped];
   const questionMap = new Map(questions.map((question) => [question.id, question]));
   const columns = generateSPSSColumns(questions);
 
-  const CATEGORICAL_TYPES = new Set(['single', 'checkbox-item', 'table-cell', 'choice-group']);
+  const CATEGORICAL_TYPES = new Set(['single', 'checkbox-item', 'table-cell', 'choice-group', 'choice-group-item']);
 
   it('categorical 컬럼은 전부 value labels를 가진다 — 0빈도 보기 포함', () => {
     const categorical = columns.filter(
@@ -141,5 +161,14 @@ describe('categorical 변수 VALUE LABELS 전수 보장', () => {
       { value: 1, label: '보기A' },
       { value: 2, label: '보기B' },
     ]);
+  });
+
+  it('choice-group-item 변수는 buildValueLabels가 자체 counted 코드와 "선택" 라벨을 반환한다', () => {
+    const cgiCols = columns.filter((c) => c.type === 'choice-group-item' && c.questionId === 'q5');
+    expect(cgiCols.length).toBe(2);
+    const labels0 = buildValueLabels(cgiCols[0]!, checkboxGrouped);
+    const labels1 = buildValueLabels(cgiCols[1]!, checkboxGrouped);
+    expect(labels0).toEqual([{ value: 3, label: '선택' }]);
+    expect(labels1).toEqual([{ value: 5, label: '선택' }]);
   });
 });

--- a/tests/unit/features/builder/choice-opt-group-tab.test.tsx
+++ b/tests/unit/features/builder/choice-opt-group-tab.test.tsx
@@ -126,13 +126,131 @@ describe('ChoiceOptCellTab — 옵션 그룹 지정 UI', () => {
     expect(onChoiceGroupIdChange).toHaveBeenCalledWith('');
   });
 
-  it('체크박스·순위 세그먼트 버튼은 disabled 상태다', () => {
+  it('순위 세그먼트 버튼만 disabled 상태다', () => {
     render(<ChoiceOptCellTab {...makeProps()} />);
 
-    // 라디오는 활성, 나머지는 disabled
+    // 체크박스는 활성, 순위만 disabled
     const checkboxBtn = screen.getByRole('button', { name: /체크박스/ });
     const rankingBtn = screen.getByRole('button', { name: /순위/ });
-    expect(checkboxBtn).toBeDisabled();
+    expect(checkboxBtn).not.toBeDisabled();
     expect(rankingBtn).toBeDisabled();
+  });
+
+  it('초기 상태에서 라디오 버튼이 aria-pressed="true"다', () => {
+    render(<ChoiceOptCellTab {...makeProps()} />);
+
+    const radioBtn = screen.getByRole('button', { name: /라디오/ });
+    const checkboxBtn = screen.getByRole('button', { name: /체크박스/ });
+    expect(radioBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(checkboxBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('체크박스 버튼 클릭 시 드롭다운이 checkbox 그룹만 표시하고 "+ 새 그룹 (cb1)" 발번 문구가 나타난다', async () => {
+    const cb1: ChoiceGroup = { id: 'cg1', groupKey: 'cb1', type: 'checkbox', label: '구매품목' };
+    render(
+      <ChoiceOptCellTab
+        {...makeProps({
+          choiceGroups: [rad1, rad2, cb1],
+          groupMemberCounts: { g1: 2, g2: 3, cg1: 1 },
+        })}
+      />,
+    );
+
+    const checkboxBtn = screen.getByRole('button', { name: /체크박스/ });
+    await userEvent.click(checkboxBtn);
+
+    // 체크박스 그룹만 드롭다운에 표시되어야 한다
+    expect(screen.getByRole('option', { name: /구매품목/ })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /TV보유/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /구매의향/ })).not.toBeInTheDocument();
+
+    // "+ 새 그룹"에 cb2 발번 문구가 있어야 한다
+    expect(screen.getByRole('option', { name: /\+ 새 그룹 \(cb2\)/ })).toBeInTheDocument();
+  });
+
+  it('체크박스 세그먼트에서 "+ 새 그룹" 선택 시 type이 checkbox인 cb1 그룹이 생성된다', async () => {
+    const onChoiceGroupsChange = vi.fn();
+    const onChoiceGroupIdChange = vi.fn();
+
+    render(
+      <ChoiceOptCellTab
+        {...makeProps({
+          choiceGroups: [rad1, rad2],
+          groupMemberCounts: { g1: 2, g2: 3 },
+          onChoiceGroupsChange,
+          onChoiceGroupIdChange,
+        })}
+      />,
+    );
+
+    // 체크박스 세그먼트로 전환
+    const checkboxBtn = screen.getByRole('button', { name: /체크박스/ });
+    await userEvent.click(checkboxBtn);
+
+    // "+ 새 그룹 (cb1)" 선택
+    const select = screen.getByRole('combobox', { name: /그룹/ });
+    await userEvent.selectOptions(select, '__new__');
+
+    // 새 그룹이 checkbox type, cb1 groupKey로 생성되어야 한다
+    expect(onChoiceGroupsChange).toHaveBeenCalledOnce();
+    const newGroups: ChoiceGroup[] = onChoiceGroupsChange.mock.calls[0]![0] as ChoiceGroup[];
+    const newGroup = newGroups[newGroups.length - 1]!;
+    expect(newGroup.type).toBe('checkbox');
+    expect(newGroup.groupKey).toBe('cb1');
+
+    expect(onChoiceGroupIdChange).toHaveBeenCalledWith(newGroup.id);
+  });
+
+  it('라디오에서 체크박스로 종류 전환 시 onChoiceGroupIdChange("")가 호출된다', async () => {
+    const onChoiceGroupIdChange = vi.fn();
+
+    render(
+      <ChoiceOptCellTab
+        {...makeProps({
+          choiceGroups: [rad1],
+          groupMemberCounts: { g1: 1 },
+          choiceGroupId: 'g1',
+          onChoiceGroupIdChange,
+        })}
+      />,
+    );
+
+    const checkboxBtn = screen.getByRole('button', { name: /체크박스/ });
+    await userEvent.click(checkboxBtn);
+
+    // 다른 type 그룹에 남지 않도록 소속 해제 호출
+    expect(onChoiceGroupIdChange).toHaveBeenCalledWith('');
+  });
+
+  it('cb 그룹 소속 셀로 열리면 세그먼트가 체크박스 선택 상태(aria-pressed)로 초기화된다', () => {
+    const cb1: ChoiceGroup = { id: 'cg1', groupKey: 'cb1', type: 'checkbox', label: '구매품목' };
+
+    render(
+      <ChoiceOptCellTab
+        {...makeProps({
+          choiceGroups: [rad1, cb1],
+          groupMemberCounts: { g1: 2, cg1: 1 },
+          choiceGroupId: 'cg1',
+        })}
+      />,
+    );
+
+    const radioBtn = screen.getByRole('button', { name: /라디오/ });
+    const checkboxBtn = screen.getByRole('button', { name: /체크박스/ });
+    expect(checkboxBtn).toHaveAttribute('aria-pressed', 'true');
+    expect(radioBtn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('체크박스 종류에서 안내 문구가 체크박스용으로 바뀐다', async () => {
+    render(<ChoiceOptCellTab {...makeProps()} />);
+
+    // 초기(라디오) 안내문
+    expect(screen.getByText(/하나만 선택됩니다/)).toBeInTheDocument();
+
+    // 체크박스로 전환
+    await userEvent.click(screen.getByRole('button', { name: /체크박스/ }));
+
+    expect(screen.getByText(/여러 개를 선택할 수 있습니다/)).toBeInTheDocument();
+    expect(screen.queryByText(/하나만 선택됩니다/)).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/survey/choice-table-response-grouped.test.tsx
+++ b/tests/unit/survey/choice-table-response-grouped.test.tsx
@@ -1,8 +1,9 @@
 /**
- * 그룹별 선택 radio (choiceGroups) 렌더 동작 테스트
+ * 그룹별 선택 radio/checkbox (choiceGroups) 렌더 동작 테스트
  *
- * 픽스처: rad1(cellA, cellB), rad2(cellC), 미소속(cellD)
- * Step 1 — 실패 테스트 먼저 작성 (TDD Red 단계)
+ * 픽스처(radio): rad1(cellA, cellB), rad2(cellC), 미소속(cellD)
+ * 픽스처(checkbox): cb1(cellE, cellF) 추가 — checkbox 그룹 복수 선택 케이스
+ * Step 3 — checkbox 그룹 구현 완료 후 전체 통과
  */
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -157,6 +158,179 @@ describe('ChoiceTableResponse — 그룹별 선택 radio', () => {
     expect(inputA.checked).toBe(true);
     expect(inputB.checked).toBe(false);
     expect(inputC.checked).toBe(false);
+  });
+});
+
+/**
+ * radio 질문에 checkbox 그룹(cb1)과 radio 그룹(rad1)이 혼재하는 픽스처.
+ * - rad1: cellA, cellB (radio)
+ * - cb1: cellE, cellF (checkbox)
+ * - 미소속(default): cellD  → 질문 type=radio 이므로 default=radio
+ */
+function mixedGroupQuestion(): Question {
+  return {
+    id: 'qmix',
+    type: 'radio',
+    title: '혼합 그룹',
+    required: true,
+    order: 0,
+    tableColumns: [{ id: 'col1', label: '열1' }],
+    tableRowsData: [
+      {
+        id: 'row1',
+        label: '',
+        cells: [
+          { id: 'cellA', type: 'choice_opt', content: '', choiceLabel: '보기A', choiceGroupId: 'grp1' },
+          { id: 'cellB', type: 'choice_opt', content: '', choiceLabel: '보기B', choiceGroupId: 'grp1' },
+          { id: 'cellE', type: 'choice_opt', content: '', choiceLabel: '보기E', choiceGroupId: 'grpCb' },
+          { id: 'cellF', type: 'choice_opt', content: '', choiceLabel: '보기F', choiceGroupId: 'grpCb' },
+          { id: 'cellD', type: 'choice_opt', content: '', choiceLabel: '보기D' },
+        ],
+      },
+    ],
+    choiceGroups: [
+      { id: 'grp1', type: 'radio', groupKey: 'rad1', label: 'Radio그룹' },
+      { id: 'grpCb', type: 'checkbox', groupKey: 'cb1', label: 'CB그룹' },
+    ],
+  } as unknown as Question;
+}
+
+/**
+ * checkbox 질문에 checkbox 그룹(cb1)이 있는 픽스처.
+ * 미소속 셀도 default=checkbox 동작 검증.
+ */
+function checkboxGroupQuestion(): Question {
+  return {
+    id: 'qcb',
+    type: 'checkbox',
+    title: 'Checkbox 질문',
+    required: true,
+    order: 0,
+    tableColumns: [{ id: 'col1', label: '열1' }],
+    tableRowsData: [
+      {
+        id: 'row1',
+        label: '',
+        cells: [
+          { id: 'cellE', type: 'choice_opt', content: '', choiceLabel: '보기E', choiceGroupId: 'grpCb' },
+          { id: 'cellF', type: 'choice_opt', content: '', choiceLabel: '보기F', choiceGroupId: 'grpCb' },
+          { id: 'cellD', type: 'choice_opt', content: '', choiceLabel: '보기D' },
+        ],
+      },
+    ],
+    choiceGroups: [
+      { id: 'grpCb', type: 'checkbox', groupKey: 'cb1', label: 'CB그룹' },
+    ],
+  } as unknown as Question;
+}
+
+describe('ChoiceTableResponse — checkbox 그룹 복수 선택', () => {
+  it('cb1 셀 하나(cellE) 선택 → { cb1: [cellE] }', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse
+        question={mixedGroupQuestion()}
+        value={null}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('보기E'));
+    expect(onChange).toHaveBeenCalledWith({ cb1: ['cellE'] });
+  });
+
+  it('cellE 선택 후 cellF 추가 → { cb1: [cellE, cellF] }', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse
+        question={mixedGroupQuestion()}
+        value={{ cb1: ['cellE'] }}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('보기F'));
+    expect(onChange).toHaveBeenCalledWith({ cb1: ['cellE', 'cellF'] });
+  });
+
+  it('cellE, cellF 선택 상태에서 cellE 해제 → { cb1: [cellF] }', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse
+        question={mixedGroupQuestion()}
+        value={{ cb1: ['cellE', 'cellF'] }}
+        onChange={onChange}
+      />,
+    );
+    // 체크된 cellE 클릭 → 해제
+    fireEvent.click(screen.getByLabelText('보기E'));
+    expect(onChange).toHaveBeenCalledWith({ cb1: ['cellF'] });
+  });
+
+  it('마지막 셀도 해제하면 cb1 키가 삭제됨 → {}', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse
+        question={mixedGroupQuestion()}
+        value={{ cb1: ['cellE'] }}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('보기E'));
+    expect(onChange).toHaveBeenCalledWith({});
+  });
+
+  it('rad1 선택과 cb1 복수 선택이 한 맵에 공존: { rad1: cellA, cb1: [cellE] }', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse
+        question={mixedGroupQuestion()}
+        value={{ rad1: 'cellA' }}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('보기E'));
+    expect(onChange).toHaveBeenCalledWith({ rad1: 'cellA', cb1: ['cellE'] });
+  });
+
+  it('checkbox 그룹 선택 상태 표시: value={ cb1: [cellE] }이면 cellE만 checked', () => {
+    render(
+      <ChoiceTableResponse
+        question={mixedGroupQuestion()}
+        value={{ cb1: ['cellE'] }}
+        onChange={vi.fn()}
+      />,
+    );
+    const inputE = screen.getByLabelText('보기E') as HTMLInputElement;
+    const inputF = screen.getByLabelText('보기F') as HTMLInputElement;
+    expect(inputE.checked).toBe(true);
+    expect(inputF.checked).toBe(false);
+  });
+});
+
+describe('ChoiceTableResponse — checkbox 질문 + checkbox 그룹', () => {
+  it('checkbox 질문의 그룹 셀도 배열 응답 동작', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse
+        question={checkboxGroupQuestion()}
+        value={null}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('보기E'));
+    expect(onChange).toHaveBeenCalledWith({ cb1: ['cellE'] });
+  });
+
+  it('checkbox 질문의 미소속 셀(default=checkbox): 클릭 → { default: [cellD] }', () => {
+    const onChange = vi.fn();
+    render(
+      <ChoiceTableResponse
+        question={checkboxGroupQuestion()}
+        value={null}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('보기D'));
+    expect(onChange).toHaveBeenCalledWith({ default: ['cellD'] });
   });
 });
 

--- a/tests/unit/utils/choice-group-helpers.test.ts
+++ b/tests/unit/utils/choice-group-helpers.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_GROUP_KEY,
-  collectRadioGroups,
+  collectChoiceGroups,
   getGroupKeyOfCell,
+  getGroupTypeOfCell,
   isGroupedChoiceQuestion,
   nextGroupKey,
   pruneChoiceGroups,
@@ -12,6 +13,7 @@ import type { ChoiceGroup, Question } from '@/types/survey';
 
 const rad1: ChoiceGroup = { id: 'g1', groupKey: 'rad1', type: 'radio', label: 'TV보유' };
 const rad2: ChoiceGroup = { id: 'g2', groupKey: 'rad2', type: 'radio', label: '구매의향' };
+const cb1: ChoiceGroup = { id: 'g3', groupKey: 'cb1', type: 'checkbox', label: '복수선택' };
 
 function makeQuestion(overrides: Record<string, unknown>): Question {
   return {
@@ -36,9 +38,61 @@ const grouped = makeQuestion({
   ],
 });
 
+// rad1 + cb1 혼재 픽스처 (radio 질문)
+const mixedRadioQ = makeQuestion({
+  type: 'radio',
+  choiceGroups: [rad1, cb1],
+  tableRowsData: [
+    {
+      id: 'r1', label: '행1',
+      cells: [
+        { id: 'cellA', content: 'UHD', type: 'choice_opt', choiceGroupId: 'g1' },
+        { id: 'cellB', content: '있음', type: 'choice_opt', choiceGroupId: 'g3' },
+        { id: 'cellD', content: '미소속', type: 'choice_opt' },
+      ],
+    },
+  ],
+});
+
+// cb1 만 있는 checkbox 질문
+const cbOnlyQ = makeQuestion({
+  type: 'checkbox',
+  choiceGroups: [cb1],
+  tableRowsData: [
+    {
+      id: 'r1', label: '행1',
+      cells: [
+        { id: 'cellB', content: '있음', type: 'choice_opt', choiceGroupId: 'g3' },
+        { id: 'cellD', content: '미소속', type: 'choice_opt' },
+      ],
+    },
+  ],
+});
+
+// ranking 그룹만 있는 픽스처
+const rankingOnly: ChoiceGroup = { id: 'g9', groupKey: 'rnk1', type: 'ranking', label: '순위' };
+const rankingOnlyQ = makeQuestion({
+  type: 'radio',
+  choiceGroups: [rankingOnly],
+  tableRowsData: [
+    {
+      id: 'r1', label: '행1',
+      cells: [{ id: 'cellZ', content: '항목', type: 'choice_opt', choiceGroupId: 'g9' }],
+    },
+  ],
+});
+
 describe('isGroupedChoiceQuestion', () => {
   it('radio 그룹이 있으면 true', () => {
     expect(isGroupedChoiceQuestion(grouped)).toBe(true);
+  });
+
+  it('checkbox 그룹만 있어도 true', () => {
+    expect(isGroupedChoiceQuestion(cbOnlyQ)).toBe(true);
+  });
+
+  it('ranking 그룹만 있으면 false — ranking은 제외', () => {
+    expect(isGroupedChoiceQuestion(rankingOnlyQ)).toBe(false);
   });
 
   it('choiceGroups가 없거나 비면 false - 하위호환 분기점', () => {
@@ -68,12 +122,36 @@ describe('getGroupKeyOfCell', () => {
   });
 });
 
-describe('collectRadioGroups', () => {
+describe('collectChoiceGroups', () => {
   it('명시 그룹 + 미소속 셀 존재 시 default를 멤버 셀과 함께 반환한다', () => {
-    const groups = collectRadioGroups(grouped);
+    const groups = collectChoiceGroups(grouped);
     expect(groups.map((g) => g.groupKey)).toEqual(['rad1', 'rad2', DEFAULT_GROUP_KEY]);
     expect(groups[0]!.cells.map((c) => c.id)).toEqual(['cellA', 'cellB']);
     expect(groups[2]!.cells.map((c) => c.id)).toEqual(['cellD']);
+  });
+
+  it('명시 그룹의 type 필드가 포함된다 — radio·checkbox 혼재 시 각 그룹의 type 반환', () => {
+    const groups = collectChoiceGroups(mixedRadioQ);
+    expect(groups.map((g) => g.groupKey)).toEqual(['rad1', 'cb1', DEFAULT_GROUP_KEY]);
+    expect(groups[0]!.type).toBe('radio');
+    expect(groups[1]!.type).toBe('checkbox');
+    // 미소속 default: radio 질문이므로 'radio'
+    expect(groups[2]!.type).toBe('radio');
+  });
+
+  it('checkbox 질문의 default 그룹 type은 checkbox', () => {
+    const groups = collectChoiceGroups(cbOnlyQ);
+    const def = groups.find((g) => g.groupKey === DEFAULT_GROUP_KEY);
+    expect(def).toBeDefined();
+    expect(def!.type).toBe('checkbox');
+  });
+
+  it('ranking 그룹은 수집에서 skip한다 — ranking 멤버 셀은 미소속으로 default에 귀속', () => {
+    const groups = collectChoiceGroups(rankingOnlyQ);
+    // ChoiceGroupWithCells.type 은 'radio' | 'checkbox' 만 존재(ranking skip 보장).
+    // ranking 그룹 하나만 있고 해당 셀이 1개이므로 미소속으로 default 그룹 1개만 반환.
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.groupKey).toBe(DEFAULT_GROUP_KEY);
   });
 
   it('미소속 셀이 없으면 default 그룹을 만들지 않는다', () => {
@@ -83,10 +161,10 @@ describe('collectRadioGroups', () => {
         { id: 'cellA', content: 'UHD', type: 'choice_opt', choiceGroupId: 'g1' },
       ] }],
     });
-    expect(collectRadioGroups(noDefault).map((g) => g.groupKey)).toEqual(['rad1']);
+    expect(collectChoiceGroups(noDefault).map((g) => g.groupKey)).toEqual(['rad1']);
   });
 
-  it('멤버 0인 명시 그룹은 collectRadioGroups 에서 제외된다', () => {
+  it('멤버 0인 명시 그룹은 collectChoiceGroups 에서 제외된다', () => {
     // rad1 은 멤버 있음, rad2 는 멤버 없음(phantom)
     const withPhantom = makeQuestion({
       choiceGroups: [rad1, rad2],
@@ -95,7 +173,7 @@ describe('collectRadioGroups', () => {
         { id: 'cellD', content: '미소속', type: 'choice_opt' },
       ] }],
     });
-    const groups = collectRadioGroups(withPhantom);
+    const groups = collectChoiceGroups(withPhantom);
     // rad2(g2)는 멤버 0이므로 제외. rad1 + default(미소속 셀) 만 반환.
     expect(groups.map((g) => g.groupKey)).toEqual(['rad1', DEFAULT_GROUP_KEY]);
   });
@@ -106,7 +184,36 @@ describe('collectRadioGroups', () => {
       choiceGroups: [rad1, rad2],
       tableRowsData: [{ id: 'r1', label: '행1', cells: [] }],
     });
-    expect(collectRadioGroups(allPhantom)).toEqual([]);
+    expect(collectChoiceGroups(allPhantom)).toEqual([]);
+  });
+});
+
+describe('getGroupTypeOfCell', () => {
+  it('cb1 소속 셀은 checkbox 반환', () => {
+    expect(getGroupTypeOfCell(mixedRadioQ, 'cellB')).toBe('checkbox');
+  });
+
+  it('rad1 소속 셀은 radio 반환', () => {
+    expect(getGroupTypeOfCell(mixedRadioQ, 'cellA')).toBe('radio');
+  });
+
+  it('미소속 셀: radio 질문이면 radio', () => {
+    expect(getGroupTypeOfCell(mixedRadioQ, 'cellD')).toBe('radio');
+  });
+
+  it('미소속 셀: checkbox 질문이면 checkbox', () => {
+    expect(getGroupTypeOfCell(cbOnlyQ, 'cellD')).toBe('checkbox');
+  });
+
+  it('존재하지 않는 그룹 id(ghost 참조) → 질문 type 기반 폴백', () => {
+    const broken = makeQuestion({
+      type: 'checkbox',
+      choiceGroups: [rad1],
+      tableRowsData: [{ id: 'r1', label: '행1', cells: [
+        { id: 'cellZ', content: '', type: 'choice_opt', choiceGroupId: 'ghost' },
+      ] }],
+    });
+    expect(getGroupTypeOfCell(broken, 'cellZ')).toBe('checkbox');
   });
 });
 
@@ -122,6 +229,10 @@ describe('nextGroupKey', () => {
   it('수동 오버라이드로 구멍이 나도 최대+1', () => {
     const custom: ChoiceGroup = { id: 'g9', groupKey: 'rad9', type: 'radio', label: 'x' };
     expect(nextGroupKey([custom], 'radio')).toBe('rad10');
+  });
+
+  it('cb1 이미 있을 때 cb2를 발번한다', () => {
+    expect(nextGroupKey([cb1], 'checkbox')).toBe('cb2');
   });
 });
 


### PR DESCRIPTION
> 스택 PR — base는 #89(feat/choice-groups-radio). #89 머지 후 base를 main으로 전환하거나 자동 retarget됩니다.

## Summary
- 옵션 그룹에 **checkbox 종류** 추가 — 그룹 내 복수 선택, 보기별 counted 변수(`질문코드_{groupKey}_{n}`), 그룹 라벨 접두("구매처 - 보기E"), MCGROUP `.sps` 등록(`$질문코드_{groupKey}`)
- **혼재 규칙 확정**: 그룹 type이 셀의 응답 동작을 결정, 질문 type은 미소속(default) 셀만 결정 — rad1(단일)과 cb1(복수)이 한 테이블에 공존
- 하위호환: default(미소속) 셀의 변수명(`질문코드_{n}`)·MCGROUP 세트명(`$질문코드`)·텍스트 사이드카(`질문코드_{n}_text`) 전부 그룹 도입 전과 동일 — 테스트로 고정
- 빌더 세그먼트 체크박스 활성화(type별 드롭다운, `cb{n}` 자동 발번, 종류 전환 시 소속 해제)
- 리뷰 수정 3건: MCGROUP default 세트명 호환, 사이드카 변수명 base, raw 엑셀 그룹 보기 라벨 누락

## Test Plan
- [x] 전체 스위트 1395/1395, lint 0 errors, tsc 0
- [x] 신규: 헬퍼 일반화 26 + 세그먼트 7 + 그룹 type별 응답 17 + export/MCGROUP/coverage 27
- [ ] 수동: rad1+cb1 혼재 테이블 작성·저장 → publish → rad1 하나/cb1 여러 개 선택
- [ ] 수동: .sav `Q코드_cb1_1..n` counted + .sps `$Q코드_cb1` MCGROUP 확인
- [ ] 수동: 그룹 없는 기존 checkbox 설문 변수명·세트명 불변 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)